### PR TITLE
Empty states

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: trusty
 sudo: required
 before_script:
 - npm run test:lint:js
-- npm run test:lint:wc
 script:
 - xvfb-run wct
 - if [ "$TRAVIS_BRANCH" == "master" ]; then frauci-update-version; fi

--- a/bower.json
+++ b/bower.json
@@ -5,16 +5,15 @@
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
     "d2l-colors": "^2.2.3",
-    "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#^1.0.8",
+    "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^1.0.8",
     "d2l-icons": "^3.1.2",
     "d2l-typography": "^5.3.0",
     "fetch": "^2.0.3",
     "iron-ajax": "PolymerElements/iron-ajax#^1.4.4",
     "iron-icon": "^1.0.12",
-    "polymer": "Polymer/polymer#^1.6.0"
+    "polymer": "Polymer/polymer#^1.9.2"
   },
   "devDependencies": {
-    "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
     "d2l-demo-template": "~0.0.11"
   }

--- a/bower.json
+++ b/bower.json
@@ -3,15 +3,15 @@
   "description": "Widget to display upcoming assessments",
   "main": "d2l-upcoming-assessments.html",
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.6.0",
-    "app-localize-behavior": "PolymerElements/app-localize-behavior#~0.10.0",
-    "d2l-ajax": "^3.3.0",
+    "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
     "d2l-colors": "^2.2.3",
     "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#^1.0.8",
-    "d2l-typography": "^5.3.0",
     "d2l-icons": "^3.1.2",
+    "d2l-typography": "^5.3.0",
     "fetch": "^2.0.3",
-    "iron-icon": "^1.0.12"
+    "iron-ajax": "^2.0.2",
+    "iron-icon": "^1.0.12",
+    "polymer": "Polymer/polymer#^1.6.0"
   },
   "devDependencies": {
     "web-component-tester": "^4.0.0",

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,6 @@
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^1.0.8",
     "d2l-icons": "^3.1.2",
     "d2l-typography": "^5.3.0",
-    "fetch": "^2.0.3",
     "iron-ajax": "PolymerElements/iron-ajax#^1.4.4",
     "iron-icon": "^1.0.12",
     "polymer": "Polymer/polymer#^1.9.2"

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "d2l-icons": "^3.1.2",
     "d2l-typography": "^5.3.0",
     "fetch": "^2.0.3",
-    "iron-ajax": "^2.0.2",
+    "iron-ajax": "PolymerElements/iron-ajax#^1.4.4",
     "iron-icon": "^1.0.12",
     "polymer": "Polymer/polymer#^1.6.0"
   },

--- a/bower.json
+++ b/bower.json
@@ -7,8 +7,10 @@
     "app-localize-behavior": "PolymerElements/app-localize-behavior#~0.10.0",
     "d2l-ajax": "^3.3.0",
     "d2l-colors": "^2.2.3",
+    "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#^1.0.8",
     "d2l-typography": "^5.3.0",
     "d2l-icons": "^3.1.2",
+    "fetch": "^2.0.3",
     "iron-icon": "^1.0.12"
   },
   "devDependencies": {

--- a/components/d2l-assessments-list-item.html
+++ b/components/d2l-assessments-list-item.html
@@ -21,7 +21,7 @@
 			}
 
 			.assessment-title {
-				@apply(--d2l-heading-3);
+				@apply --d2l-heading-3;
 				margin: 0;
 				font-size: 16px;
 				line-height: 0.75;
@@ -29,7 +29,7 @@
 			}
 
 			.assessment-info {
-				@apply(--d2l-body-standard-text);
+				@apply --d2l-body-standard-text;
 				font-size: 12px;
 				display: flex;
 				flex-direction: row;

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../../iron-ajax/iron-ajax.html">
 <link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="../src/localize-behavior.html">
@@ -27,21 +27,21 @@
 			}
 		</style>
 
-		<d2l-ajax
+		<iron-ajax
 			id="assessmentsRequest"
 			url="[[assessmentsUrl]]"
 			handle-as="json"
-			on-iron-ajax-response="_onAssessmentsResponse"
-			on-iron-ajax-error="_onError">
-		</d2l-ajax>
+			on-response="_onAssessmentsResponse"
+			on-error="_onError">
+		</iron-ajax>
 
-		<d2l-ajax
+		<iron-ajax
 			id="userRequest"
 			url="[[userUrl]]"
 			handle-as="json"
-			on-iron-ajax-response="_onUserResponse"
-			on-iron-ajax-error="_onError">
-		</d2l-ajax>
+			on-response="_onUserResponse"
+			on-error="_onError">
+		</iron-ajax>
 
 		<template is="dom-if" if="[[!_hasUpcomingAssessments(_assessments)]]">
 			<div class="no-upcoming-assessments">[[_noUpcomingAssessmentsMessage]]</div>

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -31,16 +31,16 @@
 			id="assessmentsRequest"
 			url="[[assessmentsUrl]]"
 			handle-as="json"
-			on-response="_onAssessmentsResponse"
-			on-error="_onError">
+			on-iron-ajax-response="_onAssessmentsResponse"
+			on-iron-ajax-error="_onError">
 		</iron-ajax>
 
 		<iron-ajax
 			id="userRequest"
 			url="[[userUrl]]"
 			handle-as="json"
-			on-response="_onUserResponse"
-			on-error="_onError">
+			on-iron-ajax-response="_onUserResponse"
+			on-iron-ajax-error="_onError">
 		</iron-ajax>
 
 		<template is="dom-if" if="[[!_hasUpcomingAssessments(_assessments)]]">
@@ -67,6 +67,10 @@
 				assessmentsUrl: String,
 				userUrl: String,
 				token: String,
+				debounceTime: {
+					type: Number,
+					value: 250
+				},
 				_assessments: {
 					type: Array,
 					value: function() {
@@ -95,7 +99,6 @@
 				if (response.detail.status === 200 || response.detail.status === 304) {
 					this._showError = false;
 					this.set('_assessments', response.detail.xhr.response);
-					this.notifyPath('_assessments.*');
 				} else {
 					this._onError();
 				}
@@ -132,17 +135,16 @@
 			},
 
 			_onAssessmentsUrlChanged: function() {
-				this.debounce('getAssessmentsInfo', this._getAssessmentsInfo, 250);
+				this.debounce('getAssessmentsInfo', this._getAssessmentsInfo, this.debounceTime);
 			},
 
 			_onUserUrlChanged: function() {
-				this.debounce('getUserInfo', this._getUserInfo, 250);
+				this.debounce('getUserInfo', this._getUserInfo, this.debounceTime);
 			},
 
 			_hasUpcomingAssessments: function() {
-				return this._assessments && this._assessments.length;
+				return this._assessments && this._assessments.length > 0;
 			}
-
 		});
 
 	</script>

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -32,7 +32,8 @@
 			url="[[assessmentsUrl]]"
 			handle-as="json"
 			on-response="_onAssessmentsResponse"
-			on-error="_onError">
+			on-error="_onError"
+			debounce-duration="300">
 		</iron-ajax>
 
 		<iron-ajax
@@ -40,7 +41,8 @@
 			url="[[userUrl]]"
 			handle-as="json"
 			on-response="_onUserResponse"
-			on-error="_onError">
+			on-error="_onError"
+			debounce-duration="300">
 		</iron-ajax>
 
 		<template is="dom-if" if="[[!_hasUpcomingAssessments(_assessments)]]">

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="../src/localize-behavior.html">
 <link rel="import" href="d2l-assessments-list.html">
@@ -20,23 +21,42 @@
 				margin-left: 0px;
 				margin-right: 15px;
 			}
+
+			.error-message, .no-upcoming-assessments {
+				@apply --d2l-body-compact-text;
+			}
 		</style>
 
 		<d2l-ajax
-			auto
-			url="{{endpoint}}"
+			id="assessmentsRequest"
+			url="[[assessmentsUrl]]"
 			handle-as="json"
-			on-iron-ajax-response="_onResponse"
+			on-iron-ajax-response="_onAssessmentsResponse"
 			on-iron-ajax-error="_onError">
 		</d2l-ajax>
 
-		<d2l-assessments-list assessment-items={{assessments}}></d2l-assessments-list>
+		<d2l-ajax
+			id="userRequest"
+			url="[[userUrl]]"
+			handle-as="json"
+			on-iron-ajax-response="_onUserResponse"
+			on-iron-ajax-error="_onError">
+		</d2l-ajax>
 
-		<template is="dom-if" if="[[_showRequestFailedError]]">
-			<div class="error-message">{{localize('requestFailedErr')}}</div>
+		<template is="dom-if" if="[[!_hasUpcomingAssessments(_assessments)]]">
+			<div class="no-upcoming-assessments">[[_noUpcomingAssessmentsMessage]]</div>
+		</template>
+
+		<template is="dom-if" if="[[_hasUpcomingAssessments(_assessments)]]">
+			<d2l-assessments-list assessment-items=[[_assessments]]></d2l-assessments-list>
+		</template>
+
+		<template is="dom-if" if="[[_showError]]">
+			<div class="error-message">[[localize('errorMessage')]]</div>
 		</template>
 	</template>
 
+	<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
 	<script>
 		'use strict';
 
@@ -44,64 +64,75 @@
 			is: 'd2l-upcoming-assessments',
 
 			properties: {
-				endpoint: String,
-
-				assessments: {
+				assessmentsUrl: String,
+				userUrl: String,
+				token: String,
+				_assessments: {
 					type: Array,
 					value: function() {
 						return [];
 					}
 				},
-
-				_showRequestFailedError: {
+				_userName: String,
+				_showError: {
 					type: Boolean,
 					value: false
-				}
+				},
+				_noUpcomingAssessmentsMessage: String
 			},
 
 			behaviors: [
-				window.D2L.UpcomingAssessments.LocalizeBehavior
+				window.D2L.UpcomingAssessments.LocalizeBehavior,
+				window.D2L.Hypermedia.HMConstantsBehavior
 			],
 
-			ready: function() {
-				this.$$('d2l-assessments-list').assessmentItems = [{
-					'title': 'Math Assignment',
-					'courseName': 'Math',
-					'itemType': 'Assignment',
-					'dueDate': '2017-04-05',
-					'isCompleted': true
-				}, {
-					'title': 'Math Quiz',
-					'courseName': 'Math',
-					'itemType': 'Quiz',
-					'dueDate': '2017-04-06'
-				}, {
-					'title': 'Science Quiz',
-					'courseName': 'Science',
-					'itemType': 'Quiz',
-					'dueDate': '2017-04-08',
-					'isCompleted': true
-				}, {
-					'title': 'History Assignment',
-					'courseName': 'History',
-					'itemType': 'Assignment',
-					'dueDate': '2017-04-08',
-					'isCompleted': true
-				}];
+			observers: [
+				'_onAssessmentsUrlChanged(assessmentsUrl, token)',
+				'_onUserUrlChanged(userUrl, token)'
+			],
+
+			_onAssessmentsResponse: function(response) {
+				if (response.detail.status === 200 || response.detail.status === 304) {
+					this._showError = false;
+					this.set('_assessments', response.detail.xhr.response);
+					this.notifyPath('_assessments.*');
+				} else {
+					this._onError();
+				}
 			},
 
-			_onResponse: function(response) {
+			_onUserResponse: function(response) {
 				if (response.detail.status === 200 || response.detail.status === 304) {
-					this.set('_showRequestFailedError', false);
-					this.set('assessments', response.detail.xhr.response);
-					this.notifyPath('assessments.*');
+					var userEntity = window.D2L.Hypermedia.Siren.Parse(response.detail.xhr.response);
+
+					this._userName = (userEntity.getSubEntityByRel(this.HypermediaRels.firstName) || { properties: {} }).properties.name;
+					this._showError = false;
+					this._noUpcomingAssessmentsMessage = this.localize('noUpcomingAssessments', 'userName', this._userName);
 				} else {
 					this._onError();
 				}
 			},
 
 			_onError: function() {
-				this.set('_showRequestFailedError', true);
+				this._showError = true;
+			},
+
+			_onAssessmentsUrlChanged: function(assessmentsUrl, token) {
+				this.$.assessmentsRequest.headers = {
+					Authorization: 'Bearer ' + token
+				};
+				this.$.assessmentsRequest.generateRequest();
+			},
+
+			_onUserUrlChanged: function(userUrl, token) {
+				this.$.userRequest.headers = {
+					Authorization: 'Bearer ' + token
+				};
+				this.$.userRequest.generateRequest();
+			},
+
+			_hasUpcomingAssessments: function() {
+				return this._assessments && this._assessments.length;
 			}
 
 		});

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -67,10 +67,6 @@
 				assessmentsUrl: String,
 				userUrl: String,
 				token: String,
-				debounceTime: {
-					type: Number,
-					value: 250
-				},
 				_assessments: {
 					type: Array,
 					value: function() {
@@ -135,16 +131,18 @@
 			},
 
 			_onAssessmentsUrlChanged: function() {
-				this.debounce('getAssessmentsInfo', this._getAssessmentsInfo, this.debounceTime);
+				this.debounce('getAssessmentsInfo', this._getAssessmentsInfo, this._debounceTime);
 			},
 
 			_onUserUrlChanged: function() {
-				this.debounce('getUserInfo', this._getUserInfo, this.debounceTime);
+				this.debounce('getUserInfo', this._getUserInfo, this._debounceTime);
 			},
 
 			_hasUpcomingAssessments: function() {
 				return this._assessments && this._assessments.length > 0;
-			}
+			},
+
+			_debounceTime: 250
 		});
 
 	</script>

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -32,8 +32,7 @@
 			url="[[assessmentsUrl]]"
 			handle-as="json"
 			on-response="_onAssessmentsResponse"
-			on-error="_onError"
-			debounce-duration="300">
+			on-error="_onError">
 		</iron-ajax>
 
 		<iron-ajax
@@ -41,8 +40,7 @@
 			url="[[userUrl]]"
 			handle-as="json"
 			on-response="_onUserResponse"
-			on-error="_onError"
-			debounce-duration="300">
+			on-error="_onError">
 		</iron-ajax>
 
 		<template is="dom-if" if="[[!_hasUpcomingAssessments(_assessments)]]">
@@ -115,22 +113,30 @@
 				}
 			},
 
-			_onError: function() {
-				this._showError = true;
-			},
-
-			_onAssessmentsUrlChanged: function(assessmentsUrl, token) {
+			_getAssessmentsInfo: function() {
 				this.$.assessmentsRequest.headers = {
-					Authorization: 'Bearer ' + token
+					Authorization: 'Bearer ' + this.token
 				};
 				this.$.assessmentsRequest.generateRequest();
 			},
 
-			_onUserUrlChanged: function(userUrl, token) {
+			_getUserInfo: function() {
 				this.$.userRequest.headers = {
-					Authorization: 'Bearer ' + token
+					Authorization: 'Bearer ' + this.token
 				};
 				this.$.userRequest.generateRequest();
+			},
+
+			_onError: function() {
+				this._showError = true;
+			},
+
+			_onAssessmentsUrlChanged: function() {
+				this.debounce('getAssessmentsInfo', this._getAssessmentsInfo, 250);
+			},
+
+			_onUserUrlChanged: function() {
+				this.debounce('getUserInfo', this._getUserInfo, 250);
 			},
 
 			_hasUpcomingAssessments: function() {

--- a/demo/data/assessments.json
+++ b/demo/data/assessments.json
@@ -1,0 +1,29 @@
+[
+    {
+        "title":"Math Assignment",
+        "courseName":"Math",
+        "itemType":"Assignment",
+        "dueDate":"2017-04-05",
+        "isCompleted":true
+    },
+    {
+        "title":"Math Quiz",
+        "courseName":"Math",
+        "itemType":"Quiz",
+        "dueDate":"2017-04-06"
+    },
+    {
+        "title":"Science Quiz",
+        "courseName":"Science",
+        "itemType":"Quiz",
+        "dueDate":"2017-04-08",
+        "isCompleted":true
+    },
+    {
+        "title":"History Assignment",
+        "courseName":"History",
+        "itemType":"Assignment",
+        "dueDate":"2017-04-08",
+        "isCompleted":true
+    }
+]

--- a/demo/data/user.json
+++ b/demo/data/user.json
@@ -1,0 +1,27 @@
+{
+    "class":[
+        "user"
+    ],
+    "entities":[
+        {
+            "class":[
+                "display",
+                "name"
+            ],
+            "properties":{
+                "name":"Jane Doe"
+            },
+            "rel":[
+                "https://api.brightspace.com/rels/display-name"
+            ]
+        },
+        {
+            "properties":{
+                "name":"Jane"
+            },
+            "rel":[
+                "https://api.brightspace.com/rels/first-name"
+            ]
+        }
+    ]
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,6 +8,14 @@
 
 		<link rel="import" href="../../d2l-demo-template/d2l-demo-template.html">
 		<link rel="import" href="../components/d2l-upcoming-assessments.html">
+
+		<style>
+			d2l-upcoming-assessments {
+				max-width: 500px;
+				box-shadow: 1px 1px 10px gray;
+				padding: 10px;
+			}
+		</style>
 	</head>
 	<body>
 		<d2l-demo-template title="d2l-upcoming-assessments">
@@ -15,7 +23,24 @@
 				<!-- your actions -->
 			</div>
 			<div class="d2l-demo-fixture">
-				<d2l-upcoming-assessments></d2l-upcoming-assessments>
+				<h2>With Assessments</h2>
+				<d2l-upcoming-assessments
+					assessments-url="data/assessments.json"
+					user-url="data/user.json"
+					token="foozleberries">
+				</d2l-upcoming-assessments>
+
+				<h2>Empty State</h2>
+				<d2l-upcoming-assessments
+					user-url="data/user.json"
+					token="foozleberries">
+				</d2l-upcoming-assessments>
+
+				<h2>Error State</h2>
+				<d2l-upcoming-assessments
+					user-url="does-not-exist.json"
+					token="foozleberries">
+				</d2l-upcoming-assessments>
 			</div>
 		</d2l-demo-template>
 	</body>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "postinstall": "bower install",
-    "test": "npm run test:lint:js && npm run test:lint:wc && wct",
+    "test": "npm run test:lint:js && wct",
     "test:lint:js": "./node_modules/.bin/eslint --ext .js,.html .",
     "test:lint:wc": "polylint --root components/ --no-recursion",
     "test:no-lint": "wct -p"

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   },
   "scripts": {
     "postinstall": "bower install",
-    "test": "npm run test:lint:js && wct",
+    "test": "npm run test:lint:js && npm run test:wct",
     "test:lint:js": "./node_modules/.bin/eslint --ext .js,.html .",
     "test:lint:wc": "polylint --root components/ --no-recursion",
-    "test:no-lint": "wct -p"
+    "test:wct": "wct -p"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "postinstall": "bower install",
     "test": "npm run test:lint:js && npm run test:wct",
     "test:lint:js": "./node_modules/.bin/eslint --ext .js,.html .",
-    "test:lint:wc": "polylint --root components/ --no-recursion",
-    "test:wct": "wct -p"
+    "test:lint:wc": "polymer lint --root components/*",
+    "test:wct": "polymer test -p"
   },
   "repository": {
     "type": "git",
@@ -33,7 +33,6 @@
     "eslint-config-google": "^0.7.0",
     "eslint-plugin-html": "^1.7.0",
     "frau-ci": "^1.33.2",
-    "polylint": "^2.10.4",
-    "web-component-tester": "^4.2.2"
+    "polymer-cli": "^0.17.0"
   }
 }

--- a/polymer.json
+++ b/polymer.json
@@ -1,0 +1,5 @@
+{
+  "lint": {
+    "rules": ["polymer-2-hybrid"]
+  }
+}

--- a/src/lang/en.html
+++ b/src/lang/en.html
@@ -15,7 +15,7 @@
 		en: {
 			'dueDate': 'Due: {dueDate}',
 			'errorMessage': 'There seems to be a problem loading this widget. We’re working on it and will have it up ASAP.',
-			'noUpcomingAssessments': 'Woo-hoo! It looks like {userName} is all caught up!'
+			'noUpcomingAssessments': "{userName} doesn't have any upcoming assignments."
 		}
 	};
 </script>

--- a/src/lang/en.html
+++ b/src/lang/en.html
@@ -14,7 +14,8 @@
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangEnBehavior = {
 		en: {
 			'dueDate': 'Due: {dueDate}',
-			'requestFailedErr': 'We could not get your upcoming work items. Please try again later.'
+			'errorMessage': 'There seems to be a problem loading this widget. We’re working on it and will have it up ASAP.',
+			'noUpcomingAssessments': 'Woo-hoo! It looks like {userName} is all caught up!'
 		}
 	};
 </script>

--- a/src/localize-behavior.html
+++ b/src/localize-behavior.html
@@ -37,6 +37,7 @@
 							|| 'en-us';
 					}
 				},
+				useKeyIfMissing: true,
 				resources: {
 					value: function() {
 						return {
@@ -57,7 +58,6 @@
 				}
 			},
 			_determineLanguage: function(locale, resources) {
-				this.useKeyIfMissing = true;
 				locale = locale.toLowerCase();
 
 				if (resources[locale]) {

--- a/test/d2l-upcoming-assessments.html
+++ b/test/d2l-upcoming-assessments.html
@@ -16,17 +16,6 @@
 				<d2l-upcoming-assessments></d2l-upcoming-assessments>
 			</template>
 		</test-fixture>
-
-		<test-fixture id="valid-endpoint">
-			<template>
-				<d2l-upcoming-assessments
-					assessments-url="/some/path/"
-					token="foozleberries"
-					debounce-time="10">
-				</d2l-upcoming-assessments>
-			</template>
-		</test-fixture>
-
 		<script src="d2l-upcoming-assessments.js"></script>
 	</body>
 </html>

--- a/test/d2l-upcoming-assessments.html
+++ b/test/d2l-upcoming-assessments.html
@@ -19,7 +19,11 @@
 
 		<test-fixture id="valid-endpoint">
 			<template>
-				<d2l-upcoming-assessments assessments-url="/some/path/" token="foozleberries"></d2l-upcoming-assessments>
+				<d2l-upcoming-assessments
+					assessments-url="/some/path/"
+					token="foozleberries"
+					debounce-time="10">
+				</d2l-upcoming-assessments>
 			</template>
 		</test-fixture>
 

--- a/test/d2l-upcoming-assessments.html
+++ b/test/d2l-upcoming-assessments.html
@@ -19,7 +19,7 @@
 
 		<test-fixture id="valid-endpoint">
 			<template>
-				<d2l-upcoming-assessments endpoint="/some/path/"></d2l-upcoming-assessments>
+				<d2l-upcoming-assessments assessments-url="/some/path/" token="foozleberries"></d2l-upcoming-assessments>
 			</template>
 		</test-fixture>
 

--- a/test/d2l-upcoming-assessments.js
+++ b/test/d2l-upcoming-assessments.js
@@ -29,7 +29,8 @@ describe('<d2l-upcoming-assessments>', function() {
 			server = sinon.fakeServer.create();
 			server.respondImmediately = true;
 
-			element = fixture('valid-endpoint');
+			element = fixture('basic');
+			element._debounceTime = 10;
 		});
 
 		afterEach(function() {
@@ -38,13 +39,16 @@ describe('<d2l-upcoming-assessments>', function() {
 		});
 
 		it('doesn\'t display an error message when request for data is successful', function(done) {
+			var spy = sinon.spy(element, '_onAssessmentsResponse');
+
+			element.assessmentsUrl = '/some/path/';
+			element.token = 'foozleberries';
+
 			server.respondWith(
 				'GET',
-				fixture('valid-endpoint').endpoint,
+				fixture('basic').endpoint,
 				[200, {'content-type': 'application/json'}, '[]']
 			);
-
-			var spy = sinon.spy(element, '_onAssessmentsResponse');
 
 			setTimeout(function() {
 				expect(spy.callCount).to.equal(1);
@@ -54,13 +58,16 @@ describe('<d2l-upcoming-assessments>', function() {
 		});
 
 		it('displays an error message when request for data fails', function(done) {
+			var spy = sinon.spy(element, '_onError');
+
+			element.assessmentsUrl = '/some/path/';
+			element.token = 'foozleberries';
+
 			server.respondWith(
 				'GET',
-				fixture('valid-endpoint').endpoint,
+				fixture('basic').endpoint,
 				[404, {}, '']
 			);
-
-			var spy = sinon.spy(element, '_onError');
 
 			setTimeout(function() {
 				expect(spy.callCount).to.equal(1);

--- a/test/d2l-upcoming-assessments.js
+++ b/test/d2l-upcoming-assessments.js
@@ -21,17 +21,20 @@ describe('<d2l-upcoming-assessments>', function() {
 	describe('fetching data', function() {
 
 		var server;
+		var clock;
 
 		beforeEach(function() {
 			server = sinon.fakeServer.create();
 			server.respondImmediately = true;
+			clock = sinon.useFakeTimers();
 		});
 
 		afterEach(function() {
 			server.restore();
+			clock.restore();
 		});
 
-		it('doesn\'t display an error message when request for data is successful', function(done) {
+		it('doesn\'t display an error message when request for data is successful', function() {
 			server.respondWith(
 				'GET',
 				fixture('valid-endpoint').endpoint,
@@ -40,14 +43,15 @@ describe('<d2l-upcoming-assessments>', function() {
 
 			element = fixture('valid-endpoint');
 
-			setTimeout(function() {
+			clock.tick(500);
+
+			setTimeout(function(done) {
 				expect(element.$$('.error-message')).to.not.exist;
 				done();
 			});
-
 		});
 
-		it('displays an error message when request for data fails', function(done) {
+		it('displays an error message when request for data fails', function() {
 			server.respondWith(
 				'GET',
 				fixture('valid-endpoint').endpoint,
@@ -56,7 +60,9 @@ describe('<d2l-upcoming-assessments>', function() {
 
 			element = fixture('valid-endpoint');
 
-			setTimeout(function() {
+			clock.tick(500);
+
+			setTimeout(function(done) {
 				expect(element.$$('.error-message')).to.exist;
 				done();
 			});

--- a/test/d2l-upcoming-assessments.js
+++ b/test/d2l-upcoming-assessments.js
@@ -20,53 +20,53 @@ describe('<d2l-upcoming-assessments>', function() {
 
 	describe('fetching data', function() {
 
+		var element;
+		var sandbox;
 		var server;
-		var clock;
 
 		beforeEach(function() {
+			sandbox = sinon.sandbox.create();
 			server = sinon.fakeServer.create();
 			server.respondImmediately = true;
-			clock = sinon.useFakeTimers();
+
+			element = fixture('valid-endpoint');
 		});
 
 		afterEach(function() {
 			server.restore();
-			clock.restore();
+			sandbox.restore();
 		});
 
-		it('doesn\'t display an error message when request for data is successful', function() {
+		it('doesn\'t display an error message when request for data is successful', function(done) {
 			server.respondWith(
 				'GET',
 				fixture('valid-endpoint').endpoint,
 				[200, {'content-type': 'application/json'}, '[]']
 			);
 
-			element = fixture('valid-endpoint');
+			var spy = sinon.spy(element, '_onAssessmentsResponse');
 
-			clock.tick(500);
-
-			setTimeout(function(done) {
+			setTimeout(function() {
+				expect(spy.callCount).to.equal(1);
 				expect(element.$$('.error-message')).to.not.exist;
 				done();
-			});
+			}, 20);
 		});
 
-		it('displays an error message when request for data fails', function() {
+		it('displays an error message when request for data fails', function(done) {
 			server.respondWith(
 				'GET',
 				fixture('valid-endpoint').endpoint,
 				[404, {}, '']
 			);
 
-			element = fixture('valid-endpoint');
+			var spy = sinon.spy(element, '_onError');
 
-			clock.tick(500);
-
-			setTimeout(function(done) {
+			setTimeout(function() {
+				expect(spy.callCount).to.equal(1);
 				expect(element.$$('.error-message')).to.exist;
 				done();
-			});
-
+			}, 20);
 		});
 
 	});


### PR DESCRIPTION
Add empty/error states, break some things out, etc. Caveats:

* Uses `iron-ajax` in, whereas we'll almost certainly want to use `d2l-fetch` instead, but decided to try to keep this simple(r) for now. As a result, there are potential race conditions since there are two endpoints with independent requests setting a global error state, but that will be solved when a _real_ workflow exists.

* Since the "assessments URL" (should probably be _activities URL_? Will rename when the real API is hooked up, if necessary, since it isn't set in the consumer yet anyway) isn't implemented, you're just going to get the "no upcoming assignments" message rather than a real error (except on the demo page). Again, that's corrected when a real workflow is implemented.

* As per designer, we're not concerned about not having a given name available from the users API, yet. This pattern exists in parent-portal-ui as well, so can be solved at the same time if it's an issue.

* Uses some Polymer 1.x helpers that won't exist in the future, but they're easily discoverable with global search, so.

* Probably some other things I'm not thinking of. (Like, the pre-data state will in the future be handled by parent-portal-ui skeleton, rather than being empty)