### PR TITLE
Add all assignments overlay

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,8 @@
     "d2l-colors": "^2.2.3",
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^1.0.8",
     "d2l-icons": "^3.1.2",
+    "d2l-link": "^3.5.1",
+    "d2l-simple-overlay": "Brightspace/simple-overlay#1.0.0",
     "d2l-typography": "^5.3.0",
     "iron-ajax": "PolymerElements/iron-ajax#^1.4.4",
     "iron-icon": "^1.0.12",

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -1,6 +1,8 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../iron-ajax/iron-ajax.html">
 <link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
+<link rel="import" href="../../d2l-link/d2l-link.html">
+<link rel="import" href="../../d2l-simple-overlay/d2l-simple-overlay.html">
 <link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="../src/localize-behavior.html">
 <link rel="import" href="d2l-assessments-list.html">
@@ -22,8 +24,16 @@
 				margin-right: 15px;
 			}
 
-			.error-message, .no-upcoming-assessments {
+			.error-message, .no-upcoming-assessments, .view-all-assignments-link > h3 {
 				@apply --d2l-body-compact-text;
+			}
+
+			.view-all-assignments-link > h3 {
+				margin-bottom: 0;
+			}
+
+			.no-assessments-in-time-frame {
+				text-align: center;
 			}
 		</style>
 
@@ -54,6 +64,22 @@
 		<template is="dom-if" if="[[_showError]]">
 			<div class="error-message">[[localize('errorMessage')]]</div>
 		</template>
+
+		<a class="view-all-assignments-link"
+			is="d2l-link"
+			on-tap="_openAllAssignmentsView"
+			on-keypress="_keypressOpenAllAssignmentsView" >
+			<h3>[[localize('viewAllAssignments')]]</h3>
+		</a>
+
+		<d2l-simple-overlay
+			id="view-all-assignments-overlay"
+			title-name="[[localize('viewAllAssignments')]]"
+			locale="[[locale]]"
+			close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]"
+			with-backdrop>
+			<div class="no-assessments-in-time-frame">[[_noAssessmentsInThisTimeFrame]]</div>
+		</d2l-simple-overlay>
 	</template>
 
 	<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
@@ -78,7 +104,8 @@
 					type: Boolean,
 					value: false
 				},
-				_noUpcomingAssessmentsMessage: String
+				_noUpcomingAssessmentsMessage: String,
+				_noAssessmentsInThisTimeFrame: String
 			},
 
 			behaviors: [
@@ -107,6 +134,7 @@
 					this._userName = (userEntity.getSubEntityByRel(this.HypermediaRels.firstName) || { properties: {} }).properties.name;
 					this._showError = false;
 					this._noUpcomingAssessmentsMessage = this.localize('noUpcomingAssessments', 'userName', this._userName);
+					this._noAssessmentsInThisTimeFrame = this.localize('noAssessmentsInThisTimeFrame', 'userName', this._userName);
 				} else {
 					this._onError();
 				}
@@ -140,6 +168,16 @@
 
 			_hasUpcomingAssessments: function() {
 				return this._assessments && this._assessments.length > 0;
+			},
+
+			_keypressOpenAllAssignmentsView: function(e) {
+				if ( e.code === 'Space' || e.code === 'Enter' ) {
+					return this._openAllAssignmentsView(e);
+				}
+			},
+
+			_openAllAssignmentsView: function() {
+				this.$['view-all-assignments-overlay'].open();
 			},
 
 			_debounceTime: 250

--- a/src/lang/en.html
+++ b/src/lang/en.html
@@ -13,9 +13,12 @@
 	*/
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangEnBehavior = {
 		en: {
+			'closeSimpleOverlayAltText': 'Close Dialog',
 			'dueDate': 'Due: {dueDate}',
 			'errorMessage': 'There seems to be a problem loading this widget. We’re working on it and will have it up ASAP.',
-			'noUpcomingAssessments': "{userName} doesn't have any upcoming assignments."
+			'noUpcomingAssessments': "{userName} doesn't have any upcoming assignments.",
+			'noAssessmentsInThisTimeFrame': "{userName} doesn't have any assignments due for this time frame.",
+			'viewAllAssignments': 'View All Assignments'
 		}
 	};
 </script>


### PR DESCRIPTION
[US87820 - View all upcoming assignments empty list page](https://rally1.rallydev.com/#/128188728532d/detail/userstory/128218236208)

Also see https://github.com/Brightspace/parent-portal-ui/pull/219

**Acceptance Criteria:**
Add link to "View All Upcoming" in widget
Launch "View all Upcoming" page

NOTE: The current implementation does not match the header design for the overlay, seen here: https://app.zeplin.io/project/58d138705fdb5c5361c515df/screen/594c04f0dd10648972532c66

The reason is that modifications need to be made to the [Simple Overlay](https://github.com/Brightspace/simple-overlay) to support slotted content in the header, but we don't want to hold up other team members from performing tasks on this screen (such as using data and stuff) while that is done. So to support parallelization a follow up PR will be done to fix the header to match the mock.