### PR TITLE
US87822 - Populate all assignments view

### DIFF
--- a/components/d2l-all-assessments-list-item.html
+++ b/components/d2l-all-assessments-list-item.html
@@ -60,7 +60,7 @@
 
 			.instructions {
 				@apply --d2l-body-compact-text;
-				font-size: 0.7rem;
+				font-size: 0.8rem;
 				font-weight: 300;
 				margin-top: 12px;
 				max-height: 2.4rem;

--- a/components/d2l-all-assessments-list-item.html
+++ b/components/d2l-all-assessments-list-item.html
@@ -117,7 +117,7 @@
 			}
 
 			return this.localize('dueDateShort', 'dueDate', dueDateString);
-		},
+		}
 
 	});
 	</script>

--- a/components/d2l-all-assessments-list-item.html
+++ b/components/d2l-all-assessments-list-item.html
@@ -68,17 +68,17 @@
 			}
 
 		</style>
-			<div class="row">
-				<d2l-icon class="activity-icon" icon="d2l-tier3:assignments"></d2l-icon>
-				<div class="info-container">
-					<h3 class="assessment-title">[[assessmentItem.name]]</h3>
-					<div class="course-name">[[assessmentItem.courseName]]</div>
-				</div>
+		<div class="row">
+			<d2l-icon class="activity-icon" icon="d2l-tier3:assignments"></d2l-icon>
+			<div class="info-container">
+				<h3 class="assessment-title">[[assessmentItem.name]]</h3>
+				<div class="course-name">[[assessmentItem.courseName]]</div>
 			</div>
-			<div class="row instructions-row">
-				<div class="spacer"></div>
-				<div class="instructions">[[assessmentItem.instructions]]</div>
-			</div>
+		</div>
+		<div class="row instructions-row">
+			<div class="spacer"></div>
+			<div class="instructions">[[assessmentItem.instructions]]</div>
+		</div>
 	</template>
 
 	<script>

--- a/components/d2l-all-assessments-list-item.html
+++ b/components/d2l-all-assessments-list-item.html
@@ -22,16 +22,6 @@
 			.assessment-title {
 				@apply --d2l-heading-3;
 				margin: 0;
-				font-size: 16px;
-				font-weight: normal;
-			}
-
-			.assessment-info {
-				@apply --d2l-body-standard-text;
-				font-size: 12px;
-				display: flex;
-				flex-direction: row;
-				align-items: center;
 			}
 
 			.row {
@@ -40,7 +30,11 @@
 			}
 
 			.course-name {
-				line-height: 1;
+				@apply --d2l-body-standard-text;
+				font-size: 0.7rem;
+				display: flex;
+				flex-direction: row;
+				align-items: center;
 			}
 
 			iron-icon.completion-icon {
@@ -55,22 +49,30 @@
 				height: 18px;
 			}
 
+			iron-icon.activity-icon {
+				width: 30px;
+				height: 30px;
+			}
+
 			iron-icon.activity-icon, .spacer {
-				flex: 0 0 75px;
+				flex: 0 0 100px;
 			}
 
 			.instructions {
 				@apply --d2l-body-compact-text;
-				font-size: 14px;
+				font-size: 0.7rem;
 				font-weight: 300;
-				margin-top: 1rem;
+				margin-top: 12px;
 				max-height: 2.4rem;
 				overflow: hidden;
+				padding-right: 100px;
 			}
 
 			@media (max-width: 767px) {
 				:host {
 					border-radius: 0px;
+					border-left: 0px;
+					border-right: 0px;
 				}
 
 				.instructions-row {
@@ -82,10 +84,8 @@
 			<div class="row">
 				<iron-icon class="activity-icon" icon="d2l-tier3:assignments"></iron-icon>
 				<div class="info-container">
-					<h3 class="assessment-title">{{assessmentItem.name}}</h3>
-					<div class="assessment-info">
-						<div class="course-name">{{assessmentItem.courseName}}</div>
-					</div>
+					<h3 class="assessment-title">[[assessmentItem.name]]</h3>
+					<div class="course-name">[[assessmentItem.courseName]]</div>
 				</div>
 			</div>
 			<div class="row instructions-row">

--- a/components/d2l-all-assessments-list-item.html
+++ b/components/d2l-all-assessments-list-item.html
@@ -50,28 +50,9 @@
 				padding-right: 100px;
 			}
 
-			.info-container {
-				display: flex;
-				justify-content: space-between;
-				width: 100%;
-				padding-right: 100px;
-			}
-
-			.item-header {
-				justify-content: space-between;
-			}
-
-			.critical-info {
-				align-self: flex-start;
-				color: var(--d2l-color-olivine);;
-				border: 1px solid var(--d2l-color-olivine);;
-				border-radius: 6px;
-				padding: 5px 20px;
-				margin-top: -5px;
-				text-transform: uppercase;
-			}
-			.critical-info:empty {
-				display: none;
+			:host-context([dir="rtl"]) .instructions {
+				padding-right: 0px;
+				padding-left: 100px;
 			}
 
 			@media (max-width: 767px) {
@@ -84,21 +65,14 @@
 				.instructions-row {
 					display: none;
 				}
-
-				.info-container {
-					padding-right: 30px;
-				}
 			}
 
 		</style>
 			<div class="row">
 				<d2l-icon class="activity-icon" icon="d2l-tier3:assignments"></d2l-icon>
 				<div class="info-container">
-					<div class="item-header">
-						<h3 class="assessment-title">[[assessmentItem.name]]</h3>
-						<div class="course-name">[[assessmentItem.courseName]]</div>
-					</div>
-					<div class="critical-info">[[_getCriticalInfo(assessmentItem)]]</div>
+					<h3 class="assessment-title">[[assessmentItem.name]]</h3>
+					<div class="course-name">[[assessmentItem.courseName]]</div>
 				</div>
 			</div>
 			<div class="row instructions-row">
@@ -121,45 +95,7 @@
 		behaviors: [
 			window.D2L.UpcomingAssessments.DateBehavior,
 			window.D2L.UpcomingAssessments.LocalizeBehavior
-		],
-
-		_isCompleted: function(item) {
-			return item.isCompleted;
-		},
-
-		_getDateString: function(dueDateUTC) {
-			var dueDateString;
-
-
-			if (calendarDateDiff === 0) {
-				dueDateString = this.localize('today');
-			} else if (calendarDateDiff === 1) {
-				dueDateString = this.localize('tomorrow');
-			} else {
-				dueDateString = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric' }).format(new Date(dueDateUTC));
-			}
-
-			return this.localize('dueDateShort', 'dueDate', dueDateString);
-		},
-
-		_getCriticalInfo: function(assessmentItem) {
-			if (assessmentItem.isComplete) {
-				return this.localize('complete');
-			}
-
-			var dueDateString;
-			var calendarDateDiff = this.getDateDiffInCalendarDays(assessmentItem.dueDate);
-
-			if (calendarDateDiff === 0) {
-				dueDateString = this.localize('today');
-			} else if (calendarDateDiff === 1) {
-				dueDateString = this.localize('tomorrow');
-			}
-
-			if (dueDateString) {
-				return this.localize('dueDateShort', 'dueDate', dueDateString);
-			}
-		}
+		]
 
 	});
 	</script>

--- a/components/d2l-all-assessments-list-item.html
+++ b/components/d2l-all-assessments-list-item.html
@@ -68,6 +68,16 @@
 				overflow: hidden;
 			}
 
+			@media (max-width: 767px) {
+				:host {
+					border-radius: 0px;
+				}
+
+				.instructions-row {
+					display: none;
+				}
+			}
+
 		</style>
 			<div class="row">
 				<iron-icon class="activity-icon" icon="d2l-tier3:assignments"></iron-icon>
@@ -78,7 +88,7 @@
 					</div>
 				</div>
 			</div>
-			<div class="row">
+			<div class="row instructions-row">
 				<div class="spacer"></div>
 				<div class="instructions">[[assessmentItem.instructions]]</div>
 			</div>

--- a/components/d2l-all-assessments-list-item.html
+++ b/components/d2l-all-assessments-list-item.html
@@ -1,8 +1,8 @@
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../d2l-icons/d2l-icon.html">
-<link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
+<link rel="import" href="../../d2l-icons/d2l-icon.html">
 <link rel="import" href="../../d2l-icons/tier3-icons.html">
+<link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="../src/behaviors/date-behavior.html">
 <link rel="import" href="../src/behaviors/localize-behavior.html">
 

--- a/components/d2l-all-assessments-list-item.html
+++ b/components/d2l-all-assessments-list-item.html
@@ -50,6 +50,27 @@
 				padding-right: 100px;
 			}
 
+			.info-container {
+				display: flex;
+				flex-direction: column;
+				width: 100%;
+				padding-right: 100px;
+			}
+
+			.item-header {
+				display: inline-flex;
+				justify-content: space-between;
+			}
+
+			.critical-info {
+				align-self: center;
+				color: var(--d2l-color-olivine);;
+				border: 1px solid var(--d2l-color-olivine);;
+				padding: 5px 20px;
+				border-radius: 6px;
+				text-transform: uppercase;
+			}
+
 			@media (max-width: 767px) {
 				:host {
 					border-radius: 0px;
@@ -60,13 +81,20 @@
 				.instructions-row {
 					display: none;
 				}
+
+				.info-container {
+					padding-right: 30px;
+				}
 			}
 
 		</style>
 			<div class="row">
 				<d2l-icon class="activity-icon" icon="d2l-tier3:assignments"></d2l-icon>
 				<div class="info-container">
-					<h3 class="assessment-title">[[assessmentItem.name]]</h3>
+					<div class="item-header">
+						<h3 class="assessment-title">[[assessmentItem.name]]</h3>
+						<span class="critical-info">[[_getCriticalInfo(assessmentItem)]]</span>
+					</div>
 					<div class="course-name">[[assessmentItem.courseName]]</div>
 				</div>
 			</div>
@@ -109,6 +137,10 @@
 			}
 
 			return this.localize('dueDateShort', 'dueDate', dueDateString);
+		},
+
+		_getCriticalInfo: function() {
+			return 'Completed';
 		}
 
 	});

--- a/components/d2l-all-assessments-list-item.html
+++ b/components/d2l-all-assessments-list-item.html
@@ -14,7 +14,7 @@
 				margin: 10px auto;
 				background-color: var(--d2l-color-white);
 				border: 1px var(--d2l-color-titanius) solid;
-				border-radius: 6px;
+				border-radius: 4px;
 				padding: 20px 0;
 			}
 

--- a/components/d2l-all-assessments-list-item.html
+++ b/components/d2l-all-assessments-list-item.html
@@ -1,0 +1,124 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-icon/iron-icon.html">
+<link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
+<link rel="import" href="../../d2l-colors/d2l-colors.html">
+<link rel="import" href="../../d2l-icons/tier1-icons.html">
+<link rel="import" href="../../d2l-icons/tier3-icons.html">
+<link rel="import" href="../src/behaviors/date-behavior.html">
+<link rel="import" href="../src/behaviors/localize-behavior.html">
+
+<dom-module id="d2l-all-assessments-list-item">
+	<template>
+		<style>
+			:host {
+				display: block;
+				margin: 10px auto;
+				background-color: var(--d2l-color-white);
+				border: 1px var(--d2l-color-titanius) solid;
+				border-radius: 6px;
+				padding: 20px 0;
+			}
+
+			.assessment-title {
+				@apply --d2l-heading-3;
+				margin: 0;
+				font-size: 16px;
+				font-weight: normal;
+			}
+
+			.assessment-info {
+				@apply --d2l-body-standard-text;
+				font-size: 12px;
+				display: flex;
+				flex-direction: row;
+				align-items: center;
+			}
+
+			.row {
+				display: flex;
+				align-items: center;
+			}
+
+			.course-name {
+				line-height: 1;
+			}
+
+			iron-icon.completion-icon {
+				fill: var(--d2l-color-olivine);
+				width: 18px;
+				height: 18px;
+			}
+
+			iron-icon.separator-icon {
+				opacity: 0.8;
+				width: 18px;
+				height: 18px;
+			}
+
+			iron-icon.activity-icon, .spacer {
+				flex: 0 0 75px;
+			}
+
+			.instructions {
+				@apply --d2l-body-compact-text;
+				font-size: 14px;
+				font-weight: 300;
+				margin-top: 1rem;
+				max-height: 2.4rem;
+				overflow: hidden;
+			}
+
+		</style>
+			<div class="row">
+				<iron-icon class="activity-icon" icon="d2l-tier3:assignments"></iron-icon>
+				<div class="info-container">
+					<h3 class="assessment-title">{{assessmentItem.name}}</h3>
+					<div class="assessment-info">
+						<div class="course-name">{{assessmentItem.courseName}}</div>
+					</div>
+				</div>
+			</div>
+			<div class="row">
+				<div class="spacer"></div>
+				<div class="instructions">[[assessmentItem.instructions]]</div>
+			</div>
+	</template>
+
+	<script>
+	'use strict';
+
+	Polymer({
+
+		is: 'd2l-all-assessments-list-item',
+
+		properties: {
+			assessmentItem: Object
+		},
+
+		behaviors: [
+			window.D2L.UpcomingAssessments.DateBehavior,
+			window.D2L.UpcomingAssessments.LocalizeBehavior
+		],
+
+		_isCompleted: function(item) {
+			return item.isCompleted;
+		},
+
+		_getDateString: function(dueDateUTC) {
+			var dueDateString;
+			var calendarDateDiff = this.getDateDiffInCalendarDays(dueDateUTC);
+
+			if (calendarDateDiff === 0) {
+				dueDateString = this.localize('today');
+			} else if (calendarDateDiff === 1) {
+				dueDateString = this.localize('tomorrow');
+			} else {
+				dueDateString = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric' }).format(new Date(dueDateUTC));
+			}
+
+			return this.localize('dueDateShort', 'dueDate', dueDateString);
+		},
+
+	});
+	</script>
+</dom-module>

--- a/components/d2l-all-assessments-list-item.html
+++ b/components/d2l-all-assessments-list-item.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../d2l-icon/d2l-icon.html">
+<link rel="import" href="../../d2l-icons/d2l-icon.html">
 <link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
 <link rel="import" href="../../d2l-icons/tier3-icons.html">
@@ -52,23 +52,26 @@
 
 			.info-container {
 				display: flex;
-				flex-direction: column;
+				justify-content: space-between;
 				width: 100%;
 				padding-right: 100px;
 			}
 
 			.item-header {
-				display: inline-flex;
 				justify-content: space-between;
 			}
 
 			.critical-info {
-				align-self: center;
+				align-self: flex-start;
 				color: var(--d2l-color-olivine);;
 				border: 1px solid var(--d2l-color-olivine);;
-				padding: 5px 20px;
 				border-radius: 6px;
+				padding: 5px 20px;
+				margin-top: -5px;
 				text-transform: uppercase;
+			}
+			.critical-info:empty {
+				display: none;
 			}
 
 			@media (max-width: 767px) {
@@ -93,9 +96,9 @@
 				<div class="info-container">
 					<div class="item-header">
 						<h3 class="assessment-title">[[assessmentItem.name]]</h3>
-						<span class="critical-info">[[_getCriticalInfo(assessmentItem)]]</span>
+						<div class="course-name">[[assessmentItem.courseName]]</div>
 					</div>
-					<div class="course-name">[[assessmentItem.courseName]]</div>
+					<div class="critical-info">[[_getCriticalInfo(assessmentItem)]]</div>
 				</div>
 			</div>
 			<div class="row instructions-row">
@@ -126,7 +129,7 @@
 
 		_getDateString: function(dueDateUTC) {
 			var dueDateString;
-			var calendarDateDiff = this.getDateDiffInCalendarDays(dueDateUTC);
+
 
 			if (calendarDateDiff === 0) {
 				dueDateString = this.localize('today');
@@ -139,8 +142,23 @@
 			return this.localize('dueDateShort', 'dueDate', dueDateString);
 		},
 
-		_getCriticalInfo: function() {
-			return 'Completed';
+		_getCriticalInfo: function(assessmentItem) {
+			if (assessmentItem.isComplete) {
+				return this.localize('complete');
+			}
+
+			var dueDateString;
+			var calendarDateDiff = this.getDateDiffInCalendarDays(assessmentItem.dueDate);
+
+			if (calendarDateDiff === 0) {
+				dueDateString = this.localize('today');
+			} else if (calendarDateDiff === 1) {
+				dueDateString = this.localize('tomorrow');
+			}
+
+			if (dueDateString) {
+				return this.localize('dueDateShort', 'dueDate', dueDateString);
+			}
 		}
 
 	});

--- a/components/d2l-all-assessments-list-item.html
+++ b/components/d2l-all-assessments-list-item.html
@@ -1,8 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../iron-icon/iron-icon.html">
+<link rel="import" href="../../d2l-icon/d2l-icon.html">
 <link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
-<link rel="import" href="../../d2l-icons/tier1-icons.html">
 <link rel="import" href="../../d2l-icons/tier3-icons.html">
 <link rel="import" href="../src/behaviors/date-behavior.html">
 <link rel="import" href="../src/behaviors/localize-behavior.html">
@@ -37,24 +36,7 @@
 				align-items: center;
 			}
 
-			iron-icon.completion-icon {
-				fill: var(--d2l-color-olivine);
-				width: 18px;
-				height: 18px;
-			}
-
-			iron-icon.separator-icon {
-				opacity: 0.8;
-				width: 18px;
-				height: 18px;
-			}
-
-			iron-icon.activity-icon {
-				width: 30px;
-				height: 30px;
-			}
-
-			iron-icon.activity-icon, .spacer {
+			.activity-icon, .spacer {
 				flex: 0 0 100px;
 			}
 
@@ -82,7 +64,7 @@
 
 		</style>
 			<div class="row">
-				<iron-icon class="activity-icon" icon="d2l-tier3:assignments"></iron-icon>
+				<d2l-icon class="activity-icon" icon="d2l-tier3:assignments"></d2l-icon>
 				<div class="info-container">
 					<h3 class="assessment-title">[[assessmentItem.name]]</h3>
 					<div class="course-name">[[assessmentItem.courseName]]</div>

--- a/components/d2l-all-assessments-list.html
+++ b/components/d2l-all-assessments-list.html
@@ -9,7 +9,7 @@
 		<style>
 			:host {
 				display: block;
-				width: 70%;
+				width: 65%;
 				min-width: 300px;
 				margin: auto;
 			}

--- a/components/d2l-all-assessments-list.html
+++ b/components/d2l-all-assessments-list.html
@@ -29,6 +29,11 @@
 				.date-header {
 					margin-left: 30px;
 				}
+
+				:host-context([dir="rtl"]) .date-header {
+					margin-left: 0px;
+					margin-right: 30px;
+				}
 			}
 		</style>
 			<template is="dom-repeat" items="[[_assessmentItemBuckets]]">

--- a/components/d2l-all-assessments-list.html
+++ b/components/d2l-all-assessments-list.html
@@ -1,0 +1,110 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
+<link rel="import" href="../src/behaviors/date-behavior.html">
+<link rel="import" href="../src/behaviors/localize-behavior.html">
+<link rel="import" href="d2l-all-assessments-list-item.html">
+
+<dom-module id="d2l-all-assessments-list">
+	<template>
+		<style>
+			:host {
+				display: block;
+			}
+
+			.list-container {
+				width: 70%;
+				min-width: 300px;
+				margin: auto;
+			}
+
+			.date-header {
+				@apply --d2l-body-compact-text;
+				font-weight: 300;
+				font-size: 12px;
+			}
+		</style>
+		<div class="list-container">
+			<template is="dom-repeat" items="[[_assessmentItemBuckets]]">
+				<div class="date-header">[[_getDueDateString(item.1)]]</div>
+				<template is="dom-repeat" items="[[item.1]]">
+					<d2l-all-assessments-list-item assessment-item="[[item]]"></d2l-assessments-list-item>
+				</template>
+			</template>
+		</div>
+	</template>
+	<script>
+		'use strict';
+
+		Polymer({
+
+			is: 'd2l-all-assessments-list',
+
+			properties: {
+				assessmentItems: {
+					type: Array,
+					value: function() {
+						return [];
+					},
+					observer: '_onAssessmentItemsChanged'
+				},
+
+				_assessmentItemBuckets: {
+					type: Array,
+					value: function() {
+						return [];
+					}
+				}
+			},
+
+			behaviors: [
+				window.D2L.UpcomingAssessments.DateBehavior,
+				window.D2L.UpcomingAssessments.LocalizeBehavior
+			],
+
+			_onAssessmentItemsChanged: function(assessmentItems) {
+				if (!this.assessmentItems) {
+					return;
+				}
+
+				var dates = new Map();
+
+				for(var i = 0; i < assessmentItems.length; i++) {
+					var dateString = new Date(assessmentItems[i].dueDate).toDateString();
+
+					console.log(dateString);
+
+					if(!dates.get(dateString)) {
+						dates.set(dateString, []);
+					}
+
+					dates.get(dateString).push(assessmentItems[i]);
+				}
+
+				this._assessmentItemBuckets = Array.from(dates);
+			},
+
+			_getDueDateString: function(activity) {
+				console.dir(activity);
+				var dueDateString;
+				var dateStringPrefix;
+				var calendarDateDiff = this.getDateDiffInCalendarDays(activity[0].dueDate);
+
+				dueDateString = new Intl.DateTimeFormat(this.locale, { weekday: 'long', month: 'long', day: 'numeric' }).format(new Date(activity[0].dueDate));
+
+				if (calendarDateDiff === 0) {
+					dateStringPrefix = this.localize('today');
+				} else if (calendarDateDiff === 1) {
+					dateStringPrefix = this.localize('tomorrow');
+				}
+
+				if (dateStringPrefix) {
+					return this.localize('dueDateLongImminent', 'prefix', dateStringPrefix, 'dueDate', dueDateString);
+				}
+
+				return dueDateString;
+
+			}
+
+		});
+	</script>
+</dom-module>

--- a/components/d2l-all-assessments-list.html
+++ b/components/d2l-all-assessments-list.html
@@ -9,9 +9,6 @@
 		<style>
 			:host {
 				display: block;
-			}
-
-			.list-container {
 				width: 70%;
 				min-width: 300px;
 				margin: auto;
@@ -22,15 +19,24 @@
 				font-weight: 300;
 				font-size: 12px;
 			}
+
+			@media (max-width: 767px) {
+				:host {
+					margin: 0 -30px;
+					width: calc(100% + 60px);
+				}
+
+				.date-header {
+					margin-left: 30px;
+				}
+			}
 		</style>
-		<div class="list-container">
 			<template is="dom-repeat" items="[[_assessmentItemBuckets]]">
 				<div class="date-header">[[_getDueDateString(item.1)]]</div>
 				<template is="dom-repeat" items="[[item.1]]">
 					<d2l-all-assessments-list-item assessment-item="[[item]]"></d2l-assessments-list-item>
 				</template>
 			</template>
-		</div>
 	</template>
 	<script>
 		'use strict';

--- a/components/d2l-all-assessments-list.html
+++ b/components/d2l-all-assessments-list.html
@@ -17,7 +17,7 @@
 			.date-header {
 				@apply --d2l-body-compact-text;
 				font-weight: 300;
-				font-size: 12px;
+				font-size: 0.7rem;
 			}
 
 			@media (max-width: 767px) {

--- a/components/d2l-all-assessments-list.html
+++ b/components/d2l-all-assessments-list.html
@@ -68,12 +68,10 @@
 
 				var dates = new Map();
 
-				for(var i = 0; i < assessmentItems.length; i++) {
+				for (var i = 0; i < assessmentItems.length; i++) {
 					var dateString = new Date(assessmentItems[i].dueDate).toDateString();
 
-					console.log(dateString);
-
-					if(!dates.get(dateString)) {
+					if (!dates.get(dateString)) {
 						dates.set(dateString, []);
 					}
 
@@ -84,7 +82,6 @@
 			},
 
 			_getDueDateString: function(activity) {
-				console.dir(activity);
 				var dueDateString;
 				var dateStringPrefix;
 				var calendarDateDiff = this.getDateDiffInCalendarDays(activity[0].dueDate);

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -7,6 +7,7 @@
 <link rel="import" href="../src/behaviors/date-behavior.html">
 <link rel="import" href="../src/behaviors/localize-behavior.html">
 <link rel="import" href="d2l-assessments-list.html">
+<link rel="import" href="d2l-all-assessments-list.html">
 
 <dom-module id="d2l-upcoming-assessments">
 	<template>
@@ -103,7 +104,9 @@
 					</div>
 				</d2l-simple-overlay-close-button>
 			</div>
-			<div class="no-assessments-in-time-frame">[[_noAssessmentsInThisTimeFrame]]</div>
+			<d2l-all-assessments-list assessment-items=[[_allActivities]]></d2l-all-assessments-list>
+			<div hidden$="[[_hasActivities(_allActivities)]]" class="no-assessments-in-time-frame">[[_noAssessmentsInThisTimeFrame]]</div>
+
 		</d2l-simple-overlay>
 	</template>
 
@@ -125,6 +128,12 @@
 					value: false
 				},
 				_assessments: {
+					type: Array,
+					value: function() {
+						return [];
+					}
+				},
+				_allActivities: {
 					type: Array,
 					value: function() {
 						return [];
@@ -198,6 +207,7 @@
 				return !showError && (!assessments || assessments.length <= 0);
 			},
 
+
 			_getUserActivityUsages: function(userEntity) {
 				var myActivitiesLink = (userEntity.getLinkByRel(this.HypermediaRels.Activities.myActivities) || {}).href;
 
@@ -261,6 +271,7 @@
 								resolve({
 									name: activity.properties.name,
 									dueDate: activity.properties.dueDate,
+									instructions: activity.properties.instructions,
 									courseName: organization.properties.name
 								});
 							});
@@ -290,6 +301,7 @@
 					.slice(0, 4);
 
 				this.set('_assessments', basicListActivities);
+				this.set('_allActivities', activities);
 			},
 
 			_keypressOpenAllAssignmentsView: function(e) {

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -100,7 +100,7 @@
 				<d2l-simple-overlay-close-button>
 					<div class="overlay-close-button-content-wrapper">
 						<d2l-icon icon="d2l-tier1:chevron-left"></d2l-icon>
-						<span>[[localize('closeSimpleOverlayText')]]</span>
+						<span>[[_closeSimpleOverlayText]]</span>
 					</div>
 				</d2l-simple-overlay-close-button>
 			</div>
@@ -120,7 +120,7 @@
 			properties: {
 				userUrl: String,
 				token: String,
-				ready: {
+				loaded: {
 					type: Boolean,
 					notify: true,
 					readOnly: true,
@@ -151,6 +151,9 @@
 				_noAssessmentsInThisTimeFrame: {
 					type: String,
 					computed: 'localize("noAssessmentsInThisTimeFrame", "userName", _userName)'
+				},
+				_closeSimpleOverlayText: {
+					type: String
 				}
 			},
 
@@ -163,6 +166,12 @@
 			observers: [
 				'_onApiConfigChanged(userUrl, token)'
 			],
+
+			ready: function() {
+				var mql = window.matchMedia('(max-width: 767px)');
+				this._updateCloseSimpleOverlayText(mql.matches);
+				mql.addListener(this._mobileBreakpointListener.bind(this));
+			},
 
 			_debounceTime: 20,
 
@@ -191,7 +200,7 @@
 						self._showError = true;
 					})
 					.then(function() {
-						self._setReady(true);
+						self._setLoaded(true);
 					});
 			},
 
@@ -337,6 +346,16 @@
 					});
 					xhr.send();
 				});
+			},
+
+			_mobileBreakpointListener: function(mqlevent) {
+				this._updateCloseSimpleOverlayText(mqlevent.matches);
+			},
+
+			_updateCloseSimpleOverlayText: function(isMobile) {
+				this._closeSimpleOverlayText = isMobile
+					? this.localize('closeSimpleOverlayTextMobile')
+					: this.localize('closeSimpleOverlayText');
 			}
 		});
 

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -6,8 +6,8 @@
 <link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="../src/behaviors/date-behavior.html">
 <link rel="import" href="../src/behaviors/localize-behavior.html">
-<link rel="import" href="d2l-assessments-list.html">
 <link rel="import" href="d2l-all-assessments-list.html">
+<link rel="import" href="d2l-assessments-list.html">
 
 <dom-module id="d2l-upcoming-assessments">
 	<template>
@@ -216,8 +216,8 @@
 				return !showError && (!assessments || assessments.length <= 0);
 			},
 
-			_hasActivities: function(assessments) {
-				return assessments && assessments.length > 0;
+			_hasActivities: function(activities) {
+				return activities && activities.length > 0;
 			},
 
 			_getUserActivityUsages: function(userEntity) {
@@ -353,7 +353,7 @@
 			},
 
 			_updateCloseSimpleOverlayText: function(isMobile) {
-				this._closeSimpleOverlayText = isMobile
+								this._closeSimpleOverlayText = isMobile
 					? this.localize('closeSimpleOverlayTextMobile')
 					: this.localize('closeSimpleOverlayText');
 			}

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -292,7 +292,7 @@
 
 								resolve({
 									name: activity.properties.name,
-                  courseName: organization.properties.name,
+									courseName: organization.properties.name,
 									dueDate: activity.properties.dueDate,
 									instructions: activity.properties.instructions,
 									isCompleted: activityIsComplete

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -93,6 +93,7 @@
 			title-name="[[localize('viewAllAssignments')]]"
 			locale="[[locale]]"
 			close-simple-overlay-alt-text="[[localize('closeSimpleOverlayText')]]"
+			no-cancel-on-outside-click
 			with-backdrop>
 			<div class="view-all-container" slot="header">
 				<d2l-simple-overlay-close-button>

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -69,26 +69,24 @@
 		</style>
 
 
-		<template is="dom-if" if="[[_showNoUpcomingAssessmentsMessage(_assessments, _showError)]]">
-			<div class="no-upcoming-assessments">[[_noUpcomingAssessments]]</div>
-		</template>
+		<div class="no-upcoming-assessments"
+			 hidden$="[[!_showNoUpcomingAssessmentsMessage(_assessments, _showError)]]">
+			 [[_noUpcomingAssessments]]
+		</div>
 
 		<template is="dom-if" if="[[_showUpcomingAssessments(_assessments, _showError)]]">
 			<d2l-assessments-list assessment-items=[[_assessments]]></d2l-assessments-list>
 		</template>
 
-		<template is="dom-if" if="[[_showError]]">
-			<div class="error-message">[[localize('errorMessage')]]</div>
-		</template>
+		<div hidden$="[[!_showError]]" class="error-message">[[localize('errorMessage')]]</div>
 
-		<template is="dom-if" if="[[!_showError]]">
-			<a class="view-all-assignments-link"
-				is="d2l-link"
-				on-tap="_openAllAssignmentsView"
-				on-keypress="_keypressOpenAllAssignmentsView" >
-				<h3>[[localize('viewAllAssignments')]]</h3>
-			</a>
-		</template>
+		<a class="view-all-assignments-link"
+			is="d2l-link"
+			on-tap="_openAllAssignmentsView"
+			on-keypress="_keypressOpenAllAssignmentsView"
+			hidden$=[[_showError]]>
+			<h3>[[localize('viewAllAssignments')]]</h3>
+		</a>
 
 		<d2l-simple-overlay
 			id="view-all-assignments-overlay"
@@ -104,7 +102,9 @@
 					</div>
 				</d2l-simple-overlay-close-button>
 			</div>
-			<d2l-all-assessments-list hidden$="[[!_hasActivities(_allActivities)]]" assessment-items=[[_allActivities]]></d2l-all-assessments-list>
+			<template is="dom-if" if="[[_hasActivities(_allActivities)]]">
+				<d2l-all-assessments-list assessment-items=[[_allActivities]]></d2l-all-assessments-list>
+			</template>
 			<div hidden$="[[_hasActivities(_allActivities)]]" class="no-assessments-in-time-frame">[[_noAssessmentsInThisTimeFrame]]</div>
 
 		</d2l-simple-overlay>
@@ -353,7 +353,7 @@
 			},
 
 			_updateCloseSimpleOverlayText: function(isMobile) {
-								this._closeSimpleOverlayText = isMobile
+				this._closeSimpleOverlayText = isMobile
 					? this.localize('closeSimpleOverlayTextMobile')
 					: this.localize('closeSimpleOverlayText');
 			}

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -104,7 +104,7 @@
 					</div>
 				</d2l-simple-overlay-close-button>
 			</div>
-			<d2l-all-assessments-list assessment-items=[[_allActivities]]></d2l-all-assessments-list>
+			<d2l-all-assessments-list hidden$="[[!_hasActivities(_allActivities)]]" assessment-items=[[_allActivities]]></d2l-all-assessments-list>
 			<div hidden$="[[_hasActivities(_allActivities)]]" class="no-assessments-in-time-frame">[[_noAssessmentsInThisTimeFrame]]</div>
 
 		</d2l-simple-overlay>
@@ -208,7 +208,7 @@
 			},
 
 			_hasActivities: function(assessments) {
-				return assessments && assessments.length;
+				return assessments && assessments.length > 0;
 			},
 
 			_getUserActivityUsages: function(userEntity) {

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -207,6 +207,9 @@
 				return !showError && (!assessments || assessments.length <= 0);
 			},
 
+			_hasActivities: function(assessments) {
+				return assessments && assessments.length;
+			},
 
 			_getUserActivityUsages: function(userEntity) {
 				var myActivitiesLink = (userEntity.getLinkByRel(this.HypermediaRels.Activities.myActivities) || {}).href;

--- a/demo/data/activities/user/169.json
+++ b/demo/data/activities/user/169.json
@@ -12,7 +12,7 @@
                         "due-date"
                     ],
                     "properties": {
-                        "date": "2017-06-28T23:00:00.000Z"
+                        "date": "2017-07-06T23:00:00.000Z"
                     },
                     "rel": [
                         "https://api.brightspace.com/rels/date"
@@ -31,6 +31,12 @@
                         "https://api.brightspace.com/rels/assignment"
                     ],
                     "href": "data/assignments/12345/assignment4.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization"
+                    ],
+                    "href": "data/organizations/123.json"
                 },
                 {
                     "rel": [
@@ -55,7 +61,7 @@
                         "due-date"
                     ],
                     "properties": {
-                        "date": "2017-06-29T23:00:00.000Z"
+                        "date": "2017-07-07T23:00:00.000Z"
                     },
                     "rel": [
                         "https://api.brightspace.com/rels/date"
@@ -89,7 +95,7 @@
                 }
             ],
             "rel": [
-                "https://api.brightspace.com/rels/user-activity-usage"
+                "https://activities.api.brightspace.com/rels/user-activity-usage"
             ]
         },
         {
@@ -104,7 +110,7 @@
                         "due-date"
                     ],
                     "properties": {
-                        "date": "2017-07-03T23:00:00.000Z"
+                        "date": "2017-07-12T23:00:00.000Z"
                     },
                     "rel": [
                         "https://api.brightspace.com/rels/date"
@@ -138,7 +144,7 @@
                 }
             ],
             "rel": [
-                "https://api.brightspace.com/rels/user-activity-usage"
+                "https://activities.api.brightspace.com/rels/user-activity-usage"
             ]
         },
         {
@@ -153,7 +159,7 @@
                         "due-date"
                     ],
                     "properties": {
-                        "date": "2017-06-24T23:00:00.000Z"
+                        "date": "2017-07-13T23:00:00.000Z"
                     },
                     "rel": [
                         "https://api.brightspace.com/rels/date"
@@ -175,13 +181,19 @@
                 },
                 {
                     "rel": [
+                        "https://api.brightspace.com/rels/organization"
+                    ],
+                    "href": "data/organizations/123.json"
+                },
+                {
+                    "rel": [
                         "https://activities.api.brightspace.com/rels/activity-usage"
                     ],
                     "href": "data/activities/assignment1/usages/123.json"
                 }
             ],
             "rel": [
-                "https://api.brightspace.com/rels/user-activity-usage"
+                "https://activities.api.brightspace.com/rels/user-activity-usage"
             ]
         }
     ],

--- a/demo/data/assignments/12345/assignment1.json
+++ b/demo/data/assignments/12345/assignment1.json
@@ -5,7 +5,7 @@
     "properties": {
         "name": "Homework 1",
         "instructions": "First homework assignment.",
-        "dueDate": "2017-06-28T23:00:00.000Z"
+        "dueDate": "2017-07-07T23:00:00.000Z"
     },
     "links": [
         {

--- a/demo/data/assignments/12345/assignment3.json
+++ b/demo/data/assignments/12345/assignment3.json
@@ -4,7 +4,7 @@
     ],
     "properties": {
         "name": "Homework 3",
-        "instructions": "Third homework assignment.",
+        "instructions": "Third homework assignment. This one has a pretty long description to make sure that the text formatting stuff works well, and yeah, I can't think of anything else to write. This should be long enough, right? Right.",
         "dueDate": "2017-07-01T05:00:00.000Z"
     },
     "links": [

--- a/src/lang/en.html
+++ b/src/lang/en.html
@@ -15,6 +15,7 @@
 		en: {
 			'closeSimpleOverlayText': 'Back to Dashboard',
 			'dueDateShort': 'Due {dueDate}',
+			'dueDateLongImminent': '{prefix}: {dueDate}',
 			'errorMessage': 'There seems to be a problem loading this widget. We’re working on it and will have it up ASAP.',
 			'noAssessmentsInThisTimeFrame': "{userName} doesn't have any assignments due for this time frame.",
 			'noUpcomingAssessments': "{userName} doesn't have any upcoming assignments.",

--- a/src/lang/en.html
+++ b/src/lang/en.html
@@ -14,6 +14,7 @@
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangEnBehavior = {
 		en: {
 			'closeSimpleOverlayText': 'Back to Dashboard',
+			'closeSimpleOverlayTextMobile': 'Dashboard',
 			'dueDateShort': 'Due {dueDate}',
 			'dueDateLongImminent': '{prefix}: {dueDate}',
 			'errorMessage': 'There seems to be a problem loading this widget. We’re working on it and will have it up ASAP.',


### PR DESCRIPTION
https://rally1.rallydev.com/#/128188728532d/detail/userstory/128262149148

Creates the "All Upcoming Activities" view and populates it. There are some minor(ish?) styling issues that I think can come in a second pass to allow all related dependencies/PRs to get in first.

Not yet covered: 
* "Complete"/"Due Today" indicators in overlay - ~will be added when #16 is merged, and it's cleared up whether the design is the same for both mobile and desktop overlay views~ Or, probably in a separate PR
* Ellipsis on instructions overflow: Cross-browser ellipsis truncation in CSS isn't a thing - will evaluate some other solutions/what's acceptable in the future polish PR

Requires: 
https://github.com/Brightspace/parent-portal-ui/pull/239
https://git.dev.d2l/projects/IE/repos/parentportal/pull-requests/124/overview