### PR TITLE
Prefer user of instructionsText over instructions

### DIFF
--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -73,7 +73,7 @@
 								name: activity.properties.name,
 								courseName: organization.properties.name,
 								dueDate: activity.properties.dueDate,
-								instructions: activity.properties.instructions,
+								instructions: activity.properties.instructionsText || activity.properties.instructions,
 								isCompleted: activityIsComplete
 							});
 						});


### PR DESCRIPTION
The former is HTML-less, whereas `instructions` contains the HTML as well.