### PR TITLE
This exists in the behavior and so is unnecessary here

### DIFF
--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -358,27 +358,6 @@
 				return this.localize('currentPeriod', 'startDate', startDateString, 'endDate', endDateString);
 			},
 
-			_fetchEntity: function(url, token) {
-
-				return new Promise(function(resolve, reject) {
-					var xhr = new XMLHttpRequest();
-					xhr.open('GET', url);
-					xhr.setRequestHeader('Accept', 'application/vnd.siren+json');
-					xhr.setRequestHeader('Authorization', 'Bearer ' + token);
-					xhr.addEventListener('load', function() {
-						if (xhr.status === 200 || xhr.status === 304) {
-							resolve(window.D2L.Hypermedia.Siren.Parse(xhr.responseText));
-						} else {
-							reject(xhr.error || xhr.status);
-						}
-					});
-					xhr.addEventListener('error', function() {
-						reject(xhr.error || xhr.status);
-					});
-					xhr.send();
-				});
-			},
-
 			_mobileBreakpointListener: function(mqlevent) {
 				this._updateCloseSimpleOverlayText(mqlevent.matches);
 			},


### PR DESCRIPTION
Duplicate code from https://github.com/Brightspace/d2l-upcoming-assessments-ui/blob/master/behaviors/d2l-upcoming-assessments-behavior.html#L160