### PR TITLE
US88471 - made View All Assignments link a footer

### DIFF
--- a/components/d2l-assessments-list.html
+++ b/components/d2l-assessments-list.html
@@ -6,6 +6,7 @@
 		<style>
 			:host {
 				display: block;
+				margin-bottom: 25px;
 			}
 
 			.date-header {

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -60,6 +60,11 @@
 				margin-bottom: 0;
 			}
 
+			.view-all-assignments-link {
+				position: absolute;
+				bottom: 0;
+			}
+
 			.no-assessments-in-time-frame {
 				text-align: center;
 			}


### PR DESCRIPTION
[US88471](https://rally1.rallydev.com/#/89963236876d/detail/userstory/133746988244)
[Related parent-portal-ui PR 315](https://github.com/Brightspace/parent-portal-ui/pull/315)

Parent portal ui PR makes this widget and the folio widget the same, which means we have to specify that the link is displayed as a footer. This does that.