### PR TITLE
US89948 - Make widget end-date-aware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: trusty
 sudo: required
 before_script:
 - npm run test:lint:js
+- npm run test:lint:wc
 - export CHROME_BIN=/usr/bin/google-chrome
 - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 - sudo gdebi --non-interactive google-chrome*.deb

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -89,6 +89,12 @@
 						&& self.getDateDiffInCalendarDays(dueDate) === 0;
 				}
 
+				var endDate;
+				var endDateEntity = response.activityUsage.getSubEntityByClass(self.HypermediaClasses.dates.endDate);
+				if (endDateEntity) {
+					endDate = endDateEntity.properties.date;
+				}
+
 				if (!orgUnitRequest) {
 					orgUnitRequest = self._fetchEntity(response.orgUnitLink, getToken, userUrl);
 					orgPromiseMap[response.orgUnitLink] = orgUnitRequest;
@@ -113,6 +119,7 @@
 								name: activity.properties.name,
 								courseName: organization.properties.name,
 								dueDate: dueDate,
+								endDate: endDate,
 								instructions: activity.properties.instructionsText || activity.properties.instructions,
 								isCompleted: activityIsComplete,
 								isDueToday: activityIsDueToday,

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -22,7 +22,7 @@
 			var assignmentEntities = activities.getSubEntitiesByClass('user-assignment-activity');
 			var quizEntities = activities.getSubEntitiesByClass('user-quiz-activity');
 			[].concat(assignmentEntities).concat(quizEntities).forEach(function(assessment) {
-				if (!assessment.getSubEntityByClass('due-date')) {
+				if (!assessment.getSubEntityByClass(self.HypermediaClasses.dates.dueDate)) {
 					return;
 				}
 				var orgUnitLink = (assessment.getLinkByRel(self.HypermediaRels.organization) || {}).href;
@@ -80,7 +80,7 @@
 				var activityIsDueToday = false;
 
 				var dueDate;
-				var dueDateEntity = response.activityUsage.getSubEntityByClass('due-date');
+				var dueDateEntity = response.activityUsage.getSubEntityByClass(self.HypermediaClasses.dates.dueDate);
 				if (dueDateEntity) {
 					dueDate = dueDateEntity.properties.date;
 					// If there is no due date, the default value of false is correct
@@ -166,7 +166,7 @@
 			return (activityEntities)
 				.map(function(assignment) {
 					return {
-						dueDate: ((assignment.getSubEntityByClass('due-date') || {}).properties || {}).date
+						dueDate: ((assignment.getSubEntityByClass(self.HypermediaClasses.dates.dueDate) || {}).properties || {}).date
 					};
 				})
 				.filter(function(item) {

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -22,7 +22,9 @@
 			var assignmentEntities = activities.getSubEntitiesByClass('user-assignment-activity');
 			var quizEntities = activities.getSubEntitiesByClass('user-quiz-activity');
 			[].concat(assignmentEntities).concat(quizEntities).forEach(function(assessment) {
-				if (!assessment.getSubEntityByClass(self.HypermediaClasses.dates.dueDate)) {
+				if (!assessment.getSubEntityByClass(self.HypermediaClasses.dates.dueDate)
+					&& !assessment.getSubEntityByClass(self.HypermediaClasses.dates.endDate)
+				) {
 					return;
 				}
 				var orgUnitLink = (assessment.getLinkByRel(self.HypermediaRels.organization) || {}).href;
@@ -173,7 +175,8 @@
 			return (activityEntities)
 				.map(function(assignment) {
 					return {
-						dueDate: ((assignment.getSubEntityByClass(self.HypermediaClasses.dates.dueDate) || {}).properties || {}).date
+						dueDate: ((assignment.getSubEntityByClass(self.HypermediaClasses.dates.dueDate) || {}).properties || {}).date,
+						endDate: ((assignment.getSubEntityByClass(self.HypermediaClasses.dates.endDate) || {}).properties || {}).date
 					};
 				})
 				.filter(function(item) {

--- a/behaviors/date-behavior.html
+++ b/behaviors/date-behavior.html
@@ -1,3 +1,5 @@
+<link rel="import" href="../../polymer/polymer.html">
+
 <script>
 	'use strict';
 
@@ -7,6 +9,7 @@
 
 		/*
 		* Behavior that performs the minimum necessary date/time functionality required
+		* @polymerBehavior
 		*/
 		window.D2L.UpcomingAssessments.DateBehavior = {
 			/*
@@ -23,6 +26,8 @@
 
 					return this.getDateDiffInCalendarDays(activityDate, startOfWeek) < 14;
 				}
+
+				return false;
 			},
 
 			/*

--- a/behaviors/date-behavior.html
+++ b/behaviors/date-behavior.html
@@ -11,17 +11,17 @@
 		window.D2L.UpcomingAssessments.DateBehavior = {
 			/*
 			* Returns true if the given activity is "upcoming" (in the future, within the 14-day window
-			* starting at the beginning of the current week
+			* starting at the beginning of the current week)
 			*/
 			isActivityUpcoming: function(activity) {
 				var currentDateTime = new Date();
-				var activityDueDateTime = new Date(activity.dueDate);
+				var activityDate = new Date(activity.dueDate || activity.endDate);
 
-				if (activityDueDateTime - currentDateTime > 0) {
+				if (activityDate - currentDateTime > 0) {
 					var startOfDay = new Date(currentDateTime).setHours(0, 0, 0, 0);
 					var startOfWeek = new Date(startOfDay).setHours(currentDateTime.getDay() * -24);
 
-					return this.getDateDiffInCalendarDays(activityDueDateTime, startOfWeek) < 14;
+					return this.getDateDiffInCalendarDays(activityDate, startOfWeek) < 14;
 				}
 			},
 
@@ -30,10 +30,10 @@
 			*/
 			getDateDiffInCalendarDays: function(date, reference) {
 				var referenceDate = reference ? new Date(reference) : new Date();
-				var activityDueDate = new Date(date);
+				var activityDate = new Date(date);
 				var startOfDay = referenceDate.setHours(0, 0, 0, 0);
 
-				return Math.floor((activityDueDate - startOfDay) / this._msPerDay);
+				return Math.floor((activityDate - startOfDay) / this._msPerDay);
 			},
 
 			_msPerDay: 86400000

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "d2l-demo-template": "~0.0.11"
+    "d2l-demo-template": "~0.0.11",
+    "web-component-tester": "^6.1.3"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
     "d2l-colors": "^2.2.3",
-    "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^2.0.1",
+    "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^2.2.0",
     "d2l-icons": "^3.1.2",
     "d2l-intl": "^0.4.1",
     "d2l-link": "^3.5.1",

--- a/components/d2l-all-assessments-list.html
+++ b/components/d2l-all-assessments-list.html
@@ -37,7 +37,7 @@
 			}
 		</style>
 			<template is="dom-repeat" items="[[_assessmentItemBuckets]]">
-				<div class="date-header">[[_getDueDateString(item.1)]]</div>
+				<div class="date-header">[[_getDateString(item.1)]]</div>
 					<div role="list">
 						<template is="dom-repeat" items="[[item.1]]">
 							<d2l-all-assessments-list-item assessment-item="[[item]]"></d2l-assessments-list-item>
@@ -83,7 +83,7 @@
 				var dates = new Map();
 
 				for (var i = 0; i < assessmentItems.length; i++) {
-					var dateString = new Date(assessmentItems[i].dueDate).toDateString();
+					var dateString = new Date(assessmentItems[i].dueDate || assessmentItems[i].endDate).toDateString();
 
 					if (!dates.get(dateString)) {
 						dates.set(dateString, []);
@@ -95,12 +95,12 @@
 				this._assessmentItemBuckets = Array.from(dates);
 			},
 
-			_getDueDateString: function(activity) {
-				var dueDateString;
+			_getDateString: function(activity) {
+				var dateString;
 				var dateStringPrefix;
-				var calendarDateDiff = this.getDateDiffInCalendarDays(activity[0].dueDate);
+				var calendarDateDiff = this.getDateDiffInCalendarDays(activity[0].dueDate || activity[0].endDate);
 
-				dueDateString = new Intl.DateTimeFormat(this.locale, { weekday: 'long', month: 'long', day: 'numeric' }).format(new Date(activity[0].dueDate));
+				dateString = new Intl.DateTimeFormat(this.locale, { weekday: 'long', month: 'long', day: 'numeric' }).format(new Date(activity[0].dueDate || activity[0].endDate));
 
 				if (calendarDateDiff === 0) {
 					dateStringPrefix = this.localize('today');
@@ -109,11 +109,10 @@
 				}
 
 				if (dateStringPrefix) {
-					return this.localize('dueDateLongImminent', 'prefix', dateStringPrefix, 'dueDate', dueDateString);
+					return this.localize('dueDateLongImminent', 'prefix', dateStringPrefix, 'dueDate', dateString);
 				}
 
-				return dueDateString;
-
+				return dateString;
 			}
 
 		});

--- a/components/d2l-assessments-list-item.html
+++ b/components/d2l-assessments-list-item.html
@@ -48,7 +48,7 @@
 				height: 18px;
 			}
 
-			.due-date {
+			.date {
 				font-weight: bolder;
 			}
 
@@ -57,11 +57,17 @@
 				<h3 class="assessment-title">{{assessmentItem.name}}</h3>
 				<div class="assessment-info">
 					<div class="course-name">{{assessmentItem.courseName}}</div>
-					<iron-icon class="separator-icon" icon="d2l-tier1:bullet"></iron-icon>
-					<div class="due-date">[[_getDateString(assessmentItem.dueDate)]]</div>
+					<template is="dom-if" if="[[_hasDueDate(assessmentItem)]]">
+						<iron-icon class="separator-icon" icon="d2l-tier1:bullet"></iron-icon>
+						<div class="date">[[_getDueDateString(assessmentItem.dueDate)]]</div>
+					</template>
+					<template is="dom-if" if="[[_hasEndDate(assessmentItem)]]">
+						<iron-icon class="separator-icon" icon="d2l-tier1:bullet"></iron-icon>
+						<div class="date">[[_getEndDateString(assessmentItem.endDate)]]</div>
+					</template>
 				</div>
 			</div>
-			<template is="dom-if" if="{{_isCompleted(assessmentItem)}}">
+			<template is="dom-if" if="[[_isCompleted(assessmentItem)]]">
 				<iron-icon class="completion-icon" icon="d2l-tier1:check"></iron-icon>
 			</template>
 	</template>
@@ -82,23 +88,39 @@
 			window.D2L.UpcomingAssessments.LocalizeBehavior
 		],
 
+		_hasDueDate: function(item) {
+			return !!item.dueDate;
+		},
+
+		_hasEndDate: function(item) {
+			return !!item.endDate;
+		},
+
 		_isCompleted: function(item) {
 			return item.isCompleted;
 		},
 
-		_getDateString: function(dueDateUTC) {
-			var dueDateString;
-			var calendarDateDiff = this.getDateDiffInCalendarDays(dueDateUTC);
+		_getDueDateString: function(dueDateUTC) {
+			return this._getDateString(dueDateUTC, 'dueDateShort', 'dueDate');
+		},
+
+		_getEndDateString: function(endDateUTC) {
+			return this._getDateString(endDateUTC, 'endDateShort', 'endDate');
+		},
+
+		_getDateString: function(dateUTC, langTerm, key) {
+			var dateString;
+			var calendarDateDiff = this.getDateDiffInCalendarDays(dateUTC);
 
 			if (calendarDateDiff === 0) {
-				dueDateString = this.localize('today');
+				dateString = this.localize('today');
 			} else if (calendarDateDiff === 1) {
-				dueDateString = this.localize('tomorrow');
+				dateString = this.localize('tomorrow');
 			} else {
-				dueDateString = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric' }).format(new Date(dueDateUTC));
+				dateString = new Intl.DateTimeFormat(this.locale, { month: 'long', day: 'numeric' }).format(new Date(dateUTC));
 			}
 
-			return this.localize('dueDateShort', 'dueDate', dueDateString);
+			return this.localize(langTerm, key, dateString);
 		}
 
 	});

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -138,7 +138,6 @@
 		<d2l-simple-overlay
 			id="view-all-assignments-overlay"
 			title-name="[[localize('viewAllAssignments')]]"
-			locale="[[locale]]"
 			close-simple-overlay-alt-text="[[localize('closeSimpleOverlayText')]]"
 			no-cancel-on-outside-click
 			with-backdrop

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -313,10 +313,10 @@
 
 				activities = activities
 					.filter(function(activity) {
-						return activity.dueDate;
+						return activity.dueDate || activity.endDate;
 					})
 					.sort(function(a, b) {
-						return a.dueDate > b.dueDate;
+						return (a.dueDate || a.endDate) > (b.dueDate || b.endDate);
 					});
 
 				var upcomingActivities = activities

--- a/lang/en.html
+++ b/lang/en.html
@@ -21,6 +21,7 @@
 			'currentPeriod': '{startDate} - {endDate}',
 			'dueDateShort': 'Due {dueDate}',
 			'dueDateLongImminent': '{prefix}: {dueDate}',
+			'endDateShort': 'Ends {endDate}',
 			'errorMessage': 'There seems to be a problem loading this widget. We’re working on it and will have it up ASAP.',
 			'goNextText': 'next',
 			'goPreviousText': 'previous',

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   },
   "scripts": {
     "postinstall": "bower install",
-    "test": "npm run test:lint:js && npm run test:wct",
-    "test:local": "npm run test:lint:js && npm run test:wct:local",
-    "test:lint:js": "./node_modules/.bin/eslint --ext .js,.html .",
-    "test:lint:wc": "polymer lint --root components/*",
+    "test": "npm run test:lint:js && npm run test:lint:wc && npm run test:wct",
+    "test:local": "npm run test:lint:js && npm run test:lint:wc && npm run test:wct:local",
+    "test:lint:js": "eslint --ext .js,.html . behaviors/ components/ demo/ lang/ test/",
+    "test:lint:wc": "polymer lint",
     "test:wct": "polymer test -p",
     "test:wct:local": "cross-env LAUNCHPAD_BROWSERS=firefox polymer test -p --skip-plugin sauce"
   },
@@ -36,6 +36,6 @@
     "eslint-config-google": "^0.7.0",
     "eslint-plugin-html": "^1.7.0",
     "frau-ci": "^1.33.2",
-    "polymer-cli": "^0.17.0"
+    "polymer-cli": "^1.5.2"
   }
 }

--- a/test/behaviors/d2l-upcoming-assessments-behavior.js
+++ b/test/behaviors/d2l-upcoming-assessments-behavior.js
@@ -281,6 +281,12 @@ describe('d2l upcoming assessments behavior', function() {
 					date: assignmentDueDate
 				},
 				rel: ['https://api.brightspace.com/rels/date']
+			}, {
+				class: ['end-date'],
+				properties: {
+					date: assignmentDueDate
+				},
+				rel: ['https://api.brightspace.com/rels/date']
 			}],
 			links: [{
 				rel: ['self'],
@@ -298,6 +304,12 @@ describe('d2l upcoming assessments behavior', function() {
 			class: ['activity', 'quiz-activity'],
 			entities: [{
 				class: ['due-date'],
+				properties: {
+					date: assignmentDueDate
+				},
+				rel: ['https://api.brightspace.com/rels/date']
+			}, {
+				class: ['end-date'],
 				properties: {
 					date: assignmentDueDate
 				},
@@ -493,7 +505,7 @@ describe('d2l upcoming assessments behavior', function() {
 				});
 		});
 
-		it('should set the response name, courseName, and dueDate property values correctly', function() {
+		it('should set the response name, courseName, dueDate, and endDate property values correctly with an assignment', function() {
 			var publishedActivityUsage = JSON.parse(JSON.stringify(baseActivityUsage));
 			publishedActivityUsage.class.push('published');
 			var activityUsageEntity = window.D2L.Hypermedia.Siren.Parse(publishedActivityUsage);
@@ -515,10 +527,11 @@ describe('d2l upcoming assessments behavior', function() {
 					expect(response[0].name).to.equal(assignmentName);
 					expect(response[0].courseName).to.equal(organizationName);
 					expect(response[0].dueDate).to.equal(assignmentDueDate);
+					expect(response[0].endDate).to.equal(assignmentDueDate);
 				});
 		});
 
-		it('should set the response name, courseName, and dueDate property values correctly with a quiz', function() {
+		it('should set the response name, courseName, dueDate, and endDate property values correctly with a quiz', function() {
 			var publishedActivityUsage = JSON.parse(JSON.stringify(baseActivityQuizUsage));
 			publishedActivityUsage.class.push('published');
 			var activityUsageEntity = window.D2L.Hypermedia.Siren.Parse(publishedActivityUsage);
@@ -540,6 +553,7 @@ describe('d2l upcoming assessments behavior', function() {
 					expect(response[0].name).to.equal(assignmentName);
 					expect(response[0].courseName).to.equal(organizationName);
 					expect(response[0].dueDate).to.equal(assignmentDueDate);
+					expect(response[0].endDate).to.equal(assignmentDueDate);
 				});
 		});
 

--- a/test/behaviors/date-behavior-consumer.html
+++ b/test/behaviors/date-behavior-consumer.html
@@ -1,0 +1,13 @@
+<link rel="import" href="../../behaviors/date-behavior.html">
+
+<dom-module id="date-behavior-consumer">
+	<script>
+		'use strict';
+		Polymer({
+			is: 'date-behavior-consumer',
+			behaviors: [
+				window.D2L.UpcomingAssessments.DateBehavior
+			]
+		});
+	</script>
+</dom-module>

--- a/test/behaviors/date-behavior.html
+++ b/test/behaviors/date-behavior.html
@@ -6,16 +6,16 @@
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
 
-		<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
-		<link rel="import" href="d2l-upcoming-assessments-behavior-consumer.html">
+		<script src="https://s.brightspace.com/lib/siren-parser/5.2.2/siren-parser.js"></script>
+		<link rel="import" href="date-behavior-consumer.html">
 	</head>
 	<body>
-		<test-fixture id="d2l-upcoming-assessments-behavior-fixture">
+		<test-fixture id="date-behavior-fixture">
 			<template>
-				<d2l-upcoming-assessments-behavior-consumer></d2l-upcoming-assessments-behavior-consumer>
+				<date-behavior-consumer></date-behavior-consumer>
 			</template>
 		</test-fixture>
 
-		<script src="d2l-upcoming-assessments-behavior.js"></script>
+		<script src="date-behavior.js"></script>
 	</body>
 </html>

--- a/test/behaviors/date-behavior.js
+++ b/test/behaviors/date-behavior.js
@@ -1,0 +1,56 @@
+/* global describe, it, expect, fixture, beforeEach, expect */
+
+'use strict';
+
+describe('date behavior', function() {
+	var component;
+
+	function nowish(modifierDays) {
+		var date = new Date();
+		date.setDate(date.getDate() + modifierDays);
+		return date;
+	}
+
+	beforeEach(function() {
+		component = fixture('date-behavior-fixture');
+	});
+
+	describe('isActivityUpcoming', function() {
+		[
+			{ activity: { dueDate: nowish(0), endDate: null }, due: 'today', end: 'null', result: false },
+			{ activity: { dueDate: nowish(1), endDate: null }, due: 'tomorrow', end: 'null', result: true },
+			{ activity: { dueDate: nowish(7), endDate: null }, due: 'in 1 week', end: 'null', result: true },
+			{ activity: { dueDate: nowish(-1), endDate: null }, due: 'yesterday', end: 'null', result: false },
+			{ activity: { dueDate: nowish(15), endDate: null }, due: 'in >2 weeks', end: 'null', result: false },
+			{ activity: { dueDate: null, endDate: nowish(0) }, due: 'null', end: 'today', result: false },
+			{ activity: { dueDate: null, endDate: nowish(1) }, due: 'null', end: 'tomorrow', result: true },
+			{ activity: { dueDate: null, endDate: nowish(7) }, due: 'null', end: 'in 1 week', result: true },
+			{ activity: { dueDate: null, endDate: nowish(-1) }, due: 'null', end: 'yesterday', result: false },
+			{ activity: { dueDate: null, endDate: nowish(15) }, due: 'null', end: 'in >2 weeks', result: false }
+		].forEach(function(testCase) {
+			it('returns ' + testCase.result + ' when due date is ' + testCase.due + ' and end date is ' + testCase.end, function() {
+				var isUpcoming = component.isActivityUpcoming(testCase.activity);
+				expect(isUpcoming).to.equal(testCase.result);
+			});
+		});
+	});
+
+	describe('getDateDiffInCalendarDays', function() {
+		[
+			{ date: nowish(0), dateStr: 'today', reference: null, refStr: 'today (default)', result: 0 },
+			{ date: nowish(1), dateStr: 'tomorrow', reference: null, refStr: 'today (default)', result: 1 },
+			{ date: nowish(-1), dateStr: 'yesterday', reference: null, refStr: 'today (default)', result: -1 },
+			{ date: nowish(15), dateStr: '15 days from now', reference: null, refStr: 'today (default)', result: 15 },
+			{ date: nowish(-15), dateStr: '15 days ago', reference: null, refStr: 'today (default)', result: -15 },
+			{ date: nowish(0), dateStr: 'today', reference: nowish(0), refStr: 'today', result: 0 },
+			{ date: nowish(1), dateStr: 'tomorrow', reference: nowish(-1), refStr: 'yesterday', result: 2 },
+			{ date: nowish(-1), dateStr: 'yesterday', reference: nowish(1), refStr: 'tomorrow', result: -2 },
+			{ date: nowish(-15), dateStr: '15 days ago', reference: nowish(15), refStr: '15 days from now', result: -30 }
+		].forEach(function(testCase) {
+			it(testCase.dateStr + ' is ' + testCase.result + ' days away from ' + testCase.refStr, function() {
+				var dateDiff = component.getDateDiffInCalendarDays(testCase.date, testCase.reference);
+				expect(dateDiff).to.equal(testCase.result);
+			});
+		});
+	});
+});

--- a/test/index.html
+++ b/test/index.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
-		<script src="../../node_modules/web-component-tester/browser.js"></script>
+		<script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../node_modules/web-component-tester/browser.js"></script>
 	</head>
 	<body>
 		<script>
@@ -13,6 +13,7 @@
 			// Load and run all tests (.html, .js):
 			WCT.loadSuites([
 				'./behaviors/d2l-upcoming-assessments-behavior.html',
+				'./behaviors/date-behavior.html',
 				'./components/d2l-upcoming-assessments.html',
 				'./components/d2l-assessments-list.html',
 				'./components/d2l-assessments-list-item.html',


### PR DESCRIPTION
Quiz and assignment activities can have end dates as well as due dates; the case of quizzes, they generally _only_ have end dates since due dates are a new thing that's still feature flagged. In the case where we end up with such an activity, this change makes us treat the end date as a pseudo-due-date - i.e. if an activity only has an end date, then we display it in the widget as upcoming (if applicable) and in the overlay in the time period associated with the end date, rather than the due date.