### PR TITLE
get the line-heights to match the zeplin mocks

### DIFF
--- a/components/d2l-assessments-list-item.html
+++ b/components/d2l-assessments-list-item.html
@@ -24,7 +24,7 @@
 				@apply --d2l-heading-3;
 				margin: 0;
 				font-size: 16px;
-				line-height: 0.75;
+				line-height: 1.2rem;
 				font-weight: normal;
 			}
 
@@ -34,7 +34,6 @@
 				display: flex;
 				flex-direction: row;
 				align-items: center;
-				margin-top: 5px;
 				line-height: 1;
 			}
 
@@ -48,8 +47,8 @@
 
 			iron-icon.separator-icon {
 				opacity: 0.8;
-				width: 18px;
-				height: 18px;
+				width: 14px;
+				height: 14px;
 			}
 
 			.date {


### PR DESCRIPTION
[US88460 - Increase the line height on assignment titles in upcoming assignments widget](https://rally1.rallydev.com/#/89963236876d/detail/userstory/133704532392)

Story is a bit vague but looking at https://app.zeplin.io/project/58d138705fdb5c5361c515df/screen/58e546640a2e8b6a6e6a27e4 it seems the idea is:

Assignment title = 24px
Line underneath = 14px
Total height of the line item content-y stuff = 38px

![line-heights](https://user-images.githubusercontent.com/2243995/30182030-fca0b0be-93da-11e7-86ee-31757aeeb1d0.PNG)

This PR aims to achieve that.