### PR TITLE
Avoid problems when there are no activities for period

### DIFF
--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -144,6 +144,9 @@
 			if (overdueActivitiesLink) {
 				return this._fetchEntity(overdueActivitiesLink, getToken, userUrl);
 			}
+
+			// API doesn't include the overdue link if user doesn't have any overdue activities
+			return window.D2L.Hypermedia.Siren.Parse({});
 		},
 
 		_fetchEntity: function(url, getToken, userUrl) {

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -262,6 +262,8 @@
 						var myActivitiesLink = (userEntity.getLinkByRel(self.HypermediaRels.Activities.myActivities) || {}).href;
 						return self._loadActivitiesForPeriod(myActivitiesLink)
 							.then(function(activities) {
+								activities = activities || [];
+
 								var upcomingActivities = activities
 									.filter(function(activity) {
 										return self.isActivityUpcoming(activity);


### PR DESCRIPTION
Without this, activities is undefined so trying to call .filter() throws.