### PR TITLE
add translations

### DIFF
--- a/lang/ar.html
+++ b/lang/ar.html
@@ -2,7 +2,7 @@
 
 <script>
 	/* eslint quotes: ["error", "double"] */
-	'use strict';
+	"use strict";
 
 	window.D2L = window.D2L || {};
 	window.D2L.UpcomingAssessments = window.D2L.UpcomingAssessments || {};

--- a/lang/ar.html
+++ b/lang/ar.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 
 <script>
+	/* eslint quotes: ["error", "double"] */
 	'use strict';
 
 	window.D2L = window.D2L || {};
@@ -13,26 +14,26 @@
 	*/
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangArBehavior = {
 		ar: {
-			'activityComplete': 'Complete',
-			'activityDueToday': 'Due Today',
-			'activityEnded': 'Closed',
-			'activityOverdue': 'Overdue',
-			'assignment': 'Assignment',
-			'closeSimpleOverlayText': 'العودة إلى لوحة المعلومات',
-			'closeSimpleOverlayTextMobile': 'لوحة المعلومات',
-			'currentPeriod': '{startDate} - {endDate}',
-			'dueDateShort': 'الاستحقاق {dueDate}',
-			'dueDateLongImminent': '{prefix}: {dueDate}',
-			'endDateShort': 'Ends {endDate}',
-			'errorMessage': 'يبدو أن هناك مشكلة في تحميل هذه الأداة البرمجية. نحن نعمل على حلها في أسرع وقت ممكن.',
-			'goNextText': 'next',
-			'goPreviousText': 'previous',
-			'noAssessmentsInThisTimeFrame': 'ليس لـ {userName} أي فروض مستحقة لهذا الإطار الزمني.',
-			'noUpcomingAssessments': 'ليس لـ {userName} أي فروض قادمة.',
-			'quiz': 'Quiz',
-			'today': 'اليوم',
-			'tomorrow': 'غدًا',
-			'viewAllAssignments': 'عرض كل الفروض'
+			"activityComplete": "مكتمل",
+			"activityDueToday": "تاريخ الاستحقاق اليوم",
+			"activityEnded": "Closed",
+			"activityOverdue": "تم تجاوز تاريخ الاستحقاق",
+			"assignment": "الفرض",
+			"closeSimpleOverlayText": "العودة إلى لوحة المعلومات",
+			"closeSimpleOverlayTextMobile": "لوحة المعلومات",
+			"currentPeriod": "{startDate} - {endDate}",
+			"dueDateShort": "تاريخ الاستحقاق {dueDate}",
+			"dueDateLongImminent": "{prefix}: {dueDate}",
+			"endDateShort": "ينتهي في {endDate}",
+			"errorMessage": "يبدو أن هناك مشكلة في تحميل هذه الأداة البرمجية. نحن نعمل على حلها في أسرع وقت ممكن.",
+			"goNextText": "التالي",
+			"goPreviousText": "السابق",
+			"noAssessmentsInThisTimeFrame": "ليس لـ {userName} أي فروض مستحقة لهذا الإطار الزمني.",
+			"noUpcomingAssessments": "ليس لـ {userName} أي فروض مستحقة في الأسبوعَين المقبلَين.",
+			"quiz": "الاختبار",
+			"today": "اليوم",
+			"tomorrow": "غدًا",
+			"viewAllAssignments": "عرض كل العمل"
 		}
 	};
 </script>

--- a/lang/de.html
+++ b/lang/de.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 
 <script>
+	/* eslint quotes: ["error", "double"] */
 	'use strict';
 
 	window.D2L = window.D2L || {};
@@ -13,26 +14,26 @@
 	*/
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangDeBehavior = {
 		de: {
-			'activityComplete': 'Complete',
-			'activityDueToday': 'Due Today',
-			'activityEnded': 'Closed',
-			'activityOverdue': 'Overdue',
-			'assignment': 'Assignment',
-			'closeSimpleOverlayText': 'Zurück zum Dashboard',
-			'closeSimpleOverlayTextMobile': 'Dashboard',
-			'currentPeriod': '{startDate} - {endDate}',
-			'dueDateShort': 'Abgabetermin: {dueDate}',
-			'dueDateLongImminent': '{prefix}: {dueDate}',
-			'endDateShort': 'Ends {endDate}',
-			'errorMessage': 'Offenbar gibt es ein Problem beim Laden dieses Widgets. Wir arbeiten daran und werden es so schnell wie möglich beheben.',
-			'goNextText': 'next',
-			'goPreviousText': 'previous',
-			'noAssessmentsInThisTimeFrame': '{userName} hat in diesem Zeitraum keine fälligen Übungen.',
-			'noUpcomingAssessments': '{userName} hat keine anstehenden Übungen.',
-			'quiz': 'Quiz',
-			'today': 'Heute',
-			'tomorrow': 'Morgen',
-			'viewAllAssignments': 'Alle Übungen anzeigen'
+			"activityComplete": "Abgeschlossen",
+			"activityDueToday": "Heute fällig",
+			"activityEnded": "Closed",
+			"activityOverdue": "Überfällig",
+			"assignment": "Übung",
+			"closeSimpleOverlayText": "Zurück zum Dashboard",
+			"closeSimpleOverlayTextMobile": "Dashboard",
+			"currentPeriod": "{startDate} – {endDate}",
+			"dueDateShort": "Abgabetermin: {dueDate}",
+			"dueDateLongImminent": "{prefix}: {dueDate}",
+			"endDateShort": "Endet am {endDate}",
+			"errorMessage": "Offenbar gibt es ein Problem beim Laden dieses Widgets. Wir arbeiten daran und werden es so schnell wie möglich beheben.",
+			"goNextText": "weiter",
+			"goPreviousText": "zurück",
+			"noAssessmentsInThisTimeFrame": "{userName} hat in diesem Zeitraum keine fälligen Übungen.",
+			"noUpcomingAssessments": "{userName} hat in den nächsten zwei Wochen keine fälligen Übungen.",
+			"quiz": "Test",
+			"today": "Heute",
+			"tomorrow": "Morgen",
+			"viewAllAssignments": "Alle Arbeiten anzeigen."
 		}
 	};
 </script>

--- a/lang/de.html
+++ b/lang/de.html
@@ -2,7 +2,7 @@
 
 <script>
 	/* eslint quotes: ["error", "double"] */
-	'use strict';
+	"use strict";
 
 	window.D2L = window.D2L || {};
 	window.D2L.UpcomingAssessments = window.D2L.UpcomingAssessments || {};

--- a/lang/en.html
+++ b/lang/en.html
@@ -2,7 +2,7 @@
 
 <script>
 	/* eslint quotes: ["error", "double"] */
-	'use strict';
+	"use strict";
 
 	window.D2L = window.D2L || {};
 	window.D2L.UpcomingAssessments = window.D2L.UpcomingAssessments || {};

--- a/lang/en.html
+++ b/lang/en.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 
 <script>
+	/* eslint quotes: ["error", "double"] */
 	'use strict';
 
 	window.D2L = window.D2L || {};
@@ -13,26 +14,26 @@
 	*/
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangEnBehavior = {
 		en: {
-			'activityComplete': 'Complete',
-			'activityDueToday': 'Due Today',
-			'activityEnded': 'Closed',
-			'activityOverdue': 'Overdue',
-			'assignment': 'Assignment',
-			'closeSimpleOverlayText': 'Back to Dashboard',
-			'closeSimpleOverlayTextMobile': 'Dashboard',
-			'currentPeriod': '{startDate} - {endDate}',
-			'dueDateShort': 'Due {dueDate}',
-			'dueDateLongImminent': '{prefix}: {dueDate}',
-			'endDateShort': 'Ends {endDate}',
-			'errorMessage': 'There seems to be a problem loading this widget. We’re working on it and will have it up ASAP.',
-			'goNextText': 'next',
-			'goPreviousText': 'previous',
-			'noAssessmentsInThisTimeFrame': '{userName} doesn\'t have any work due for this time frame.',
-			'noUpcomingAssessments': '{userName} doesn\'t have any work due in the next 2 weeks.',
-			'quiz': 'Quiz',
-			'today': 'Today',
-			'tomorrow': 'Tomorrow',
-			'viewAllAssignments': 'View All Work'
+			"activityComplete": "Complete",
+			"activityDueToday": "Due Today",
+			"activityEnded": "Closed",
+			"activityOverdue": "Overdue",
+			"assignment": "Assignment",
+			"closeSimpleOverlayText": "Back to Dashboard",
+			"closeSimpleOverlayTextMobile": "Dashboard",
+			"currentPeriod": "{startDate} - {endDate}",
+			"dueDateShort": "Due {dueDate}",
+			"dueDateLongImminent": "{prefix}: {dueDate}",
+			"endDateShort": "Ends {endDate}",
+			"errorMessage": "There seems to be a problem loading this widget. We’re working on it and will have it up ASAP.",
+			"goNextText": "next",
+			"goPreviousText": "previous",
+			"noAssessmentsInThisTimeFrame": "{userName} doesn\'t have any work due for this time frame.",
+			"noUpcomingAssessments": "{userName} doesn\'t have any work due in the next 2 weeks.",
+			"quiz": "Quiz",
+			"today": "Today",
+			"tomorrow": "Tomorrow",
+			"viewAllAssignments": "View All Work"
 		}
 	};
 </script>

--- a/lang/es.html
+++ b/lang/es.html
@@ -2,7 +2,7 @@
 
 <script>
 	/* eslint quotes: ["error", "double"] */
-	'use strict';
+	"use strict";
 
 	window.D2L = window.D2L || {};
 	window.D2L.UpcomingAssessments = window.D2L.UpcomingAssessments || {};

--- a/lang/es.html
+++ b/lang/es.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 
 <script>
+	/* eslint quotes: ["error", "double"] */
 	'use strict';
 
 	window.D2L = window.D2L || {};
@@ -13,26 +14,26 @@
 	*/
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangEsBehavior = {
 		es: {
-			'activityComplete': 'Complete',
-			'activityDueToday': 'Due Today',
-			'activityEnded': 'Closed',
-			'activityOverdue': 'Overdue',
-			'assignment': 'Assignment',
-			'closeSimpleOverlayText': 'Volver al panel',
-			'closeSimpleOverlayTextMobile': 'Panel',
-			'currentPeriod': '{startDate} - {endDate}',
-			'dueDateShort': 'Vencimiento {dueDate}',
-			'dueDateLongImminent': '{prefix}: {dueDate}',
-			'endDateShort': 'Ends {endDate}',
-			'errorMessage': 'Al parecer, hay un problema para cargar este componente. Estamos trabajando en esto y lo solucionaremos lo más pronto posible.',
-			'goNextText': 'next',
-			'goPreviousText': 'previous',
-			'noAssessmentsInThisTimeFrame': '{userName} no tiene ninguna asignación vencida para este plazo.',
-			'noUpcomingAssessments': '{userName} no tiene ninguna asignación próxima.',
-			'quiz': 'Quiz',
-			'today': 'Hoy',
-			'tomorrow': 'Mañana',
-			'viewAllAssignments': 'Ver todas las asignaciones'
+			"activityComplete": "Completo",
+			"activityDueToday": "Entregar hoy",
+			"activityEnded": "Closed",
+			"activityOverdue": "Atrasadas",
+			"assignment": "Asignación",
+			"closeSimpleOverlayText": "Volver al panel",
+			"closeSimpleOverlayTextMobile": "Panel",
+			"currentPeriod": "{startDate} - {endDate}",
+			"dueDateShort": "Vencimiento {dueDate}",
+			"dueDateLongImminent": "{prefix}: {dueDate}",
+			"endDateShort": "Finaliza el {endDate}",
+			"errorMessage": "Al parecer, hay un problema para cargar este componente. Estamos trabajando para solucionarlo y lo haremos funcionar lo antes posible.",
+			"goNextText": "siguiente",
+			"goPreviousText": "anterior",
+			"noAssessmentsInThisTimeFrame": "{userName} no tiene ninguna asignación que entregar para este plazo.",
+			"noUpcomingAssessments": "{userName} no tiene ninguna asignación que entregar en las próximas 2 semanas.",
+			"quiz": "Cuestionario",
+			"today": "Hoy",
+			"tomorrow": "Mañana",
+			"viewAllAssignments": "Ver todos los trabajos"
 		}
 	};
 </script>

--- a/lang/fr.html
+++ b/lang/fr.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 
 <script>
+	/* eslint quotes: ["error", "double"] */
 	'use strict';
 
 	window.D2L = window.D2L || {};
@@ -13,26 +14,26 @@
 	*/
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangFrBehavior = {
 		fr: {
-			'activityComplete': 'Complete',
-			'activityDueToday': 'Due Today',
-			'activityEnded': 'Closed',
-			'activityOverdue': 'Overdue',
-			'assignment': 'Assignment',
-			'closeSimpleOverlayText': 'Retour au tableau de bord',
-			'closeSimpleOverlayTextMobile': 'Tableau de bord',
-			'currentPeriod': '{startDate} - {endDate}',
-			'dueDateShort': 'Échéance {dueDate}',
-			'dueDateLongImminent': '{prefix} : {dueDate}',
-			'endDateShort': 'Ends {endDate}',
-			'errorMessage': 'Il semble y avoir un problème avec le chargement de ce composant graphique. Nous travaillons à rétablir la situation aussi rapidement que possible.',
-			'goNextText': 'next',
-			'goPreviousText': 'previous',
-			'noAssessmentsInThisTimeFrame': '{userName} n\'a aucun travail à remettre durant cette période.',
-			'noUpcomingAssessments': '{userName} n\'a aucun travail à venir.',
-			'quiz': 'Quiz',
-			'today': 'Aujourd\'hui',
-			'tomorrow': 'Demain',
-			'viewAllAssignments': 'Visualiser tous les travaux'
+			"activityComplete": "Terminer",
+			"activityDueToday": "À remettre aujourd’hui",
+			"activityEnded": "Closed",
+			"activityOverdue": "En retard",
+			"assignment": "Travail",
+			"closeSimpleOverlayText": "Retour au tableau de bord",
+			"closeSimpleOverlayTextMobile": "Tableau de bord",
+			"currentPeriod": "{startDate} - {endDate}",
+			"dueDateShort": "Échéance {dueDate}",
+			"dueDateLongImminent": "{prefix}: {dueDate}",
+			"endDateShort": "Prend fin le {endDate}",
+			"errorMessage": "Il semble y avoir un problème de chargement de ce composant graphique. Nous travaillons à remédier au problème le plus vite possible.",
+			"goNextText": "suivant",
+			"goPreviousText": "précédent",
+			"noAssessmentsInThisTimeFrame": "{userName} n'a aucun travail à remettre durant cette période.",
+			"noUpcomingAssessments": "{userName} n'a aucun travail à remettre au cours des deux prochaines semaines.",
+			"quiz": "Questionnaire",
+			"today": "Aujourd'hui",
+			"tomorrow": "Demain",
+			"viewAllAssignments": "Afficher tous les travaux"
 		}
 	};
 </script>

--- a/lang/fr.html
+++ b/lang/fr.html
@@ -2,7 +2,7 @@
 
 <script>
 	/* eslint quotes: ["error", "double"] */
-	'use strict';
+	"use strict";
 
 	window.D2L = window.D2L || {};
 	window.D2L.UpcomingAssessments = window.D2L.UpcomingAssessments || {};

--- a/lang/ja.html
+++ b/lang/ja.html
@@ -2,7 +2,7 @@
 
 <script>
 	/* eslint quotes: ["error", "double"] */
-	'use strict';
+	"use strict";
 
 	window.D2L = window.D2L || {};
 	window.D2L.UpcomingAssessments = window.D2L.UpcomingAssessments || {};

--- a/lang/ja.html
+++ b/lang/ja.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 
 <script>
+	/* eslint quotes: ["error", "double"] */
 	'use strict';
 
 	window.D2L = window.D2L || {};
@@ -13,26 +14,26 @@
 	*/
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangJaBehavior = {
 		ja: {
-			'activityComplete': 'Complete',
-			'activityDueToday': 'Due Today',
-			'activityEnded': 'Closed',
-			'activityOverdue': 'Overdue',
-			'assignment': 'Assignment',
-			'closeSimpleOverlayText': 'ダッシュボードに戻る',
-			'closeSimpleOverlayTextMobile': 'ダッシュボード',
-			'currentPeriod': '{startDate} - {endDate}',
-			'dueDateShort': '期限 {dueDate}',
-			'dueDateLongImminent': '{prefix}: {dueDate}',
-			'endDateShort': 'Ends {endDate}',
-			'errorMessage': 'このウィジェットの読み込みに問題が発生しています。復旧に向けて現在対応中です。',
-			'goNextText': 'next',
-			'goPreviousText': 'previous',
-			'noAssessmentsInThisTimeFrame': '{userName} には、この期間に期限を迎える課題がありません。',
-			'noUpcomingAssessments': '{userName} には、今後の課題がありません。',
-			'quiz': 'Quiz',
-			'today': '今日',
-			'tomorrow': '明日',
-			'viewAllAssignments': '課題をすべて表示'
+			"activityComplete": "完了",
+			"activityDueToday": "本日期限",
+			"activityEnded": "Closed",
+			"activityOverdue": "期限切れ",
+			"assignment": "課題",
+			"closeSimpleOverlayText": "ダッシュボードに戻る",
+			"closeSimpleOverlayTextMobile": "ダッシュボード",
+			"currentPeriod": "{startDate}～{endDate}",
+			"dueDateShort": "期限 {dueDate}",
+			"dueDateLongImminent": "{prefix}: {dueDate}",
+			"endDateShort": "終了 {endDate}",
+			"errorMessage": "このウィジェットの読み込み中に問題が発生したようです。できるだけ早く機能するよう、解決に取り組んでおります。",
+			"goNextText": "次へ",
+			"goPreviousText": "前へ",
+			"noAssessmentsInThisTimeFrame": "{userName} には、この期間に期限を迎える課題がありません。",
+			"noUpcomingAssessments": "{userName} には、2 週間以内に期限を迎える課題がありません。",
+			"quiz": "クイズ",
+			"today": "今日",
+			"tomorrow": "明日",
+			"viewAllAssignments": "すべての学習の表示"
 		}
 	};
 </script>

--- a/lang/ko.html
+++ b/lang/ko.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 
 <script>
+	/* eslint quotes: ["error", "double"] */
 	'use strict';
 
 	window.D2L = window.D2L || {};
@@ -13,26 +14,26 @@
 	*/
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangKoBehavior = {
 		ko: {
-			'activityComplete': 'Complete',
-			'activityDueToday': 'Due Today',
-			'activityEnded': 'Closed',
-			'activityOverdue': 'Overdue',
-			'assignment': 'Assignment',
-			'closeSimpleOverlayText': '대시보드로 돌아가기',
-			'closeSimpleOverlayTextMobile': '대시보드',
-			'currentPeriod': '{startDate} - {endDate}',
-			'dueDateShort': '기한: {dueDate}',
-			'dueDateLongImminent': '{prefix}: {dueDate}',
-			'endDateShort': 'Ends {endDate}',
-			'errorMessage': '이 위젯을 로드하는 도중 문제가 발생한 것 같습니다. 현재 문제를 확인 중이며 최대한 빨리 해결하겠습니다.',
-			'goNextText': 'next',
-			'goPreviousText': 'previous',
-			'noAssessmentsInThisTimeFrame': '{userName} 님은 이 기간이 기한인 과제가 없습니다.',
-			'noUpcomingAssessments': '{userName} 님은 예정된 과제가 없습니다.',
-			'quiz': 'Quiz',
-			'today': '오늘',
-			'tomorrow': '내일',
-			'viewAllAssignments': '모든 과제 보기'
+			"activityComplete": "완료",
+			"activityDueToday": "기한: 오늘",
+			"activityEnded": "Closed",
+			"activityOverdue": "기한 경과",
+			"assignment": "과제",
+			"closeSimpleOverlayText": "대시보드로 돌아가기",
+			"closeSimpleOverlayTextMobile": "대시보드",
+			"currentPeriod": "{startDate} - {endDate}",
+			"dueDateShort": "기한: {dueDate}",
+			"dueDateLongImminent": "{prefix}: {dueDate}",
+			"endDateShort": "{endDate} 종료",
+			"errorMessage": "이 위젯을 로드하는 도중 문제가 발생한 것 같습니다. 현재 문제를 확인 중이며 최대한 빨리 해결하겠습니다.",
+			"goNextText": "다음",
+			"goPreviousText": "이전",
+			"noAssessmentsInThisTimeFrame": "{userName} 님에게는 이 기간이 기한인 과제가 없습니다.",
+			"noUpcomingAssessments": "{userName} 님에게는 기한이 2주 이내인 과제가 없습니다.",
+			"quiz": "퀴즈",
+			"today": "오늘",
+			"tomorrow": "내일",
+			"viewAllAssignments": "모든 작업 보기"
 		}
 	};
 </script>

--- a/lang/ko.html
+++ b/lang/ko.html
@@ -2,7 +2,7 @@
 
 <script>
 	/* eslint quotes: ["error", "double"] */
-	'use strict';
+	"use strict";
 
 	window.D2L = window.D2L || {};
 	window.D2L.UpcomingAssessments = window.D2L.UpcomingAssessments || {};

--- a/lang/nl.html
+++ b/lang/nl.html
@@ -2,7 +2,7 @@
 
 <script>
 	/* eslint quotes: ["error", "double"] */
-	'use strict';
+	"use strict";
 
 	window.D2L = window.D2L || {};
 	window.D2L.UpcomingAssessments = window.D2L.UpcomingAssessments || {};

--- a/lang/nl.html
+++ b/lang/nl.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 
 <script>
+	/* eslint quotes: ["error", "double"] */
 	'use strict';
 
 	window.D2L = window.D2L || {};
@@ -13,26 +14,26 @@
 	*/
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangNlBehavior = {
 		nl: {
-			'activityComplete': 'Complete',
-			'activityDueToday': 'Due Today',
-			'activityEnded': 'Closed',
-			'activityOverdue': 'Overdue',
-			'assignment': 'Assignment',
-			'closeSimpleOverlayText': 'Terug naar dashboard',
-			'closeSimpleOverlayTextMobile': 'Dashboard',
-			'currentPeriod': '{startDate} - {endDate}',
-			'dueDateShort': 'Uiterste datum {dueDate}',
-			'dueDateLongImminent': '{prefix}: {dueDate}',
-			'endDateShort': 'Ends {endDate}',
-			'errorMessage': 'Er lijkt een probleem op te treden bij het laden van deze widget. We zijn ermee bezig en zullen het probleem zo spoedig mogelijk verhelpen.',
-			'goNextText': 'next',
-			'goPreviousText': 'previous',
-			'noAssessmentsInThisTimeFrame': '{userName} heeft geen opdrachten die binnen dit tijdskader af moeten zijn.',
-			'noUpcomingAssessments': '{userName} heeft geen komende opdrachten.',
-			'quiz': 'Quiz',
-			'today': 'Vandaag',
-			'tomorrow': 'Morgen',
-			'viewAllAssignments': 'Alle opdrachten weergeven'
+			"activityComplete": "Voltooien",
+			"activityDueToday": "Moet vandaag af",
+			"activityEnded": "Closed",
+			"activityOverdue": "Achterstallig",
+			"assignment": "Opdracht",
+			"closeSimpleOverlayText": "Terug naar dashboard",
+			"closeSimpleOverlayTextMobile": "Dashboard",
+			"currentPeriod": "{startDate} - {endDate}",
+			"dueDateShort": "Uiterste datum {dueDate}",
+			"dueDateLongImminent": "{prefix}: {dueDate}",
+			"endDateShort": "Eindigt op {endDate}",
+			"errorMessage": "Er lijkt een probleem op te treden bij het laden van deze widget. We zijn ermee bezig en zullen het probleem zo spoedig mogelijk verhelpen.",
+			"goNextText": "volgende",
+			"goPreviousText": "vorige",
+			"noAssessmentsInThisTimeFrame": "{userName} heeft geen opdrachten die binnen dit tijdskader af moeten zijn.",
+			"noUpcomingAssessments": "{userName} heeft geen opdrachten die in de komende 2 weken af moeten zijn.",
+			"quiz": "Test",
+			"today": "Vandaag",
+			"tomorrow": "Morgen",
+			"viewAllAssignments": "Al het werk weergeven"
 		}
 	};
 </script>

--- a/lang/pt.html
+++ b/lang/pt.html
@@ -2,7 +2,7 @@
 
 <script>
 	/* eslint quotes: ["error", "double"] */
-	'use strict';
+	"use strict";
 
 	window.D2L = window.D2L || {};
 	window.D2L.UpcomingAssessments = window.D2L.UpcomingAssessments || {};

--- a/lang/pt.html
+++ b/lang/pt.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 
 <script>
+	/* eslint quotes: ["error", "double"] */
 	'use strict';
 
 	window.D2L = window.D2L || {};
@@ -13,26 +14,26 @@
 	*/
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangPtBehavior = {
 		pt: {
-			'activityComplete': 'Complete',
-			'activityDueToday': 'Due Today',
-			'activityEnded': 'Closed',
-			'activityOverdue': 'Overdue',
-			'assignment': 'Assignment',
-			'closeSimpleOverlayText': 'Voltar ao Painel',
-			'closeSimpleOverlayTextMobile': 'Painel',
-			'currentPeriod': '{startDate} - {endDate}',
-			'dueDateShort': 'Vencimento em {dueDate}',
-			'dueDateLongImminent': '{prefix}: {dueDate}',
-			'endDateShort': 'Ends {endDate}',
-			'errorMessage': 'Parece ter ocorrido um problema ao carregar este widget. Estamos trabalhando nisso e ele voltará a funcionar EM BREVE.',
-			'goNextText': 'next',
-			'goPreviousText': 'previous',
-			'noAssessmentsInThisTimeFrame': '{userName} não tem nenhuma atribuição para entrega nesse intervalo de tempo.',
-			'noUpcomingAssessments': '{userName} não tem nenhuma atribuição futura.',
-			'quiz': 'Quiz',
-			'today': 'Hoje',
-			'tomorrow': 'Amanhã',
-			'viewAllAssignments': 'Exibir todas as Atribuições'
+			"activityComplete": "Concluído",
+			"activityDueToday": "Expira hoje",
+			"activityEnded": "Closed",
+			"activityOverdue": "Atrasadas",
+			"assignment": "Atribuição",
+			"closeSimpleOverlayText": "Voltar ao Painel",
+			"closeSimpleOverlayTextMobile": "Painel",
+			"currentPeriod": "{startDate} - {endDate}",
+			"dueDateShort": "Vencimento em {dueDate}",
+			"dueDateLongImminent": "{prefix}: {dueDate}",
+			"endDateShort": "Termina em {endDate}",
+			"errorMessage": "Parece ter ocorrido um problema ao carregar este widget. Estamos trabalhando nisso e voltará a funcionar EM BREVE.",
+			"goNextText": "próximo",
+			"goPreviousText": "anterior",
+			"noAssessmentsInThisTimeFrame": "{userName} não tem nenhuma atribuição para entrega nesse intervalo de tempo.",
+			"noUpcomingAssessments": "{userName} não tem nenhuma atribuição que expira nas próximas 2 semanas.",
+			"quiz": "Questionário",
+			"today": "Hoje",
+			"tomorrow": "Amanhã",
+			"viewAllAssignments": "Exibir todos os trabalho"
 		}
 	};
 </script>

--- a/lang/sv.html
+++ b/lang/sv.html
@@ -2,7 +2,7 @@
 
 <script>
 	/* eslint quotes: ["error", "double"] */
-	'use strict';
+	"use strict";
 
 	window.D2L = window.D2L || {};
 	window.D2L.UpcomingAssessments = window.D2L.UpcomingAssessments || {};

--- a/lang/sv.html
+++ b/lang/sv.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 
 <script>
+	/* eslint quotes: ["error", "double"] */
 	'use strict';
 
 	window.D2L = window.D2L || {};
@@ -13,26 +14,26 @@
 	*/
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangSvBehavior = {
 		sv: {
-			'activityComplete': 'Complete',
-			'activityDueToday': 'Due Today',
-			'activityEnded': 'Closed',
-			'activityOverdue': 'Overdue',
-			'assignment': 'Assignment',
-			'closeSimpleOverlayText': 'Tillbaka till instrumentpanelen',
-			'closeSimpleOverlayTextMobile': 'Instrumentpanel',
-			'currentPeriod': '{startDate} - {endDate}',
-			'dueDateShort': 'Förfallodatum {dueDate}',
-			'dueDateLongImminent': '{prefix}: {dueDate}',
-			'endDateShort': 'Ends {endDate}',
-			'errorMessage': 'Ett problem uppstod när widgeten skulle laddas. Vi jobbar på att lösa det så fort som möjligt.',
-			'goNextText': 'next',
-			'goPreviousText': 'previous',
-			'noAssessmentsInThisTimeFrame': '{userName} har inga uppgifter för denna tidsram.',
-			'noUpcomingAssessments': '{userName} har inga kommande uppgifter.',
-			'quiz': 'Quiz',
-			'today': 'Idag',
-			'tomorrow': 'Imorgon',
-			'viewAllAssignments': 'Visa alla uppgifter'
+			"activityComplete": "Klart",
+			"activityDueToday": "Förfaller idag",
+			"activityEnded": "Closed",
+			"activityOverdue": "Försenat",
+			"assignment": "Uppgift",
+			"closeSimpleOverlayText": "Tillbaka till instrumentpanelen",
+			"closeSimpleOverlayTextMobile": "Instrumentpanel",
+			"currentPeriod": "{startDate} - {endDate}",
+			"dueDateShort": "Förfallodatum {dueDate}",
+			"dueDateLongImminent": "{prefix}: {dueDate}",
+			"endDateShort": "Slutar {endDate}",
+			"errorMessage": "Den här widgeten kunde inte laddas. Vi jobbar på att lösa det så fort som möjligt.",
+			"goNextText": "nästa",
+			"goPreviousText": "föregående",
+			"noAssessmentsInThisTimeFrame": "{userName} har inga uppgifter för denna tidsram.",
+			"noUpcomingAssessments": "{userName} har inga uppgifter med förfallodatum de närmaste två veckorna.",
+			"quiz": "Förhör",
+			"today": "Idag",
+			"tomorrow": "Imorgon",
+			"viewAllAssignments": "Se allt"
 		}
 	};
 </script>

--- a/lang/tr.html
+++ b/lang/tr.html
@@ -2,7 +2,7 @@
 
 <script>
 	/* eslint quotes: ["error", "double"] */
-	'use strict';
+	"use strict";
 
 	window.D2L = window.D2L || {};
 	window.D2L.UpcomingAssessments = window.D2L.UpcomingAssessments || {};

--- a/lang/tr.html
+++ b/lang/tr.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 
 <script>
+	/* eslint quotes: ["error", "double"] */
 	'use strict';
 
 	window.D2L = window.D2L || {};
@@ -13,26 +14,26 @@
 	*/
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangTrBehavior = {
 		tr: {
-			'activityComplete': 'Complete',
-			'activityDueToday': 'Due Today',
-			'activityEnded': 'Closed',
-			'activityOverdue': 'Overdue',
-			'assignment': 'Assignment',
-			'closeSimpleOverlayText': 'Panoya Geri Dön',
-			'closeSimpleOverlayTextMobile': 'Pano',
-			'currentPeriod': '{startDate} - {endDate}',
-			'dueDateShort': 'Bitiş: {dueDate}',
-			'dueDateLongImminent': '{prefix}: {dueDate}',
-			'endDateShort': 'Ends {endDate}',
-			'errorMessage': 'Bu pencere öğesi yüklenirken bir sorun oluştu. Bu sorunu çözmeye çalışıyoruz, en kısa zamanda sonuca ulaşacağız.',
-			'goNextText': 'next',
-			'goPreviousText': 'previous',
-			'noAssessmentsInThisTimeFrame': '{userName} adlı kullanıcıya ait bu zaman çerçevesinde süresi dolan herhangi bir ödev bulunmuyor.',
-			'noUpcomingAssessments': '{userName} adlı kullanıcıya ait yaklaşan ödev bulunmuyor.',
-			'quiz': 'Quiz',
-			'today': 'Bugün',
-			'tomorrow': 'Yarın',
-			'viewAllAssignments': 'Tüm Ödevleri Görüntüle'
+			"activityComplete": "Tamamla",
+			"activityDueToday": "Bugün Süresi Doluyor",
+			"activityEnded": "Closed",
+			"activityOverdue": "Gecikmiş",
+			"assignment": "Ödev",
+			"closeSimpleOverlayText": "Panoya Geri Dön",
+			"closeSimpleOverlayTextMobile": "Pano",
+			"currentPeriod": "{startDate} - {endDate}",
+			"dueDateShort": "Süresinin Dolma Tarihi: {dueDate}",
+			"dueDateLongImminent": "{prefix}: {dueDate}",
+			"endDateShort": "Şu Tarihte Sona Erer: {endDate}",
+			"errorMessage": "Bu pencere öğesi yüklenirken bir sorun oluştu. Bu sorunu çözmeye çalışıyoruz, en kısa zamanda sonuca ulaşacağız.",
+			"goNextText": "sonraki",
+			"goPreviousText": "önceki",
+			"noAssessmentsInThisTimeFrame": "Bu zaman çerçevesinde {userName} adlı kullanıcıya ait süresi dolan herhangi bir ödev bulunmuyor.",
+			"noUpcomingAssessments": "Önümüzdeki 2 hafta içinde {userName} adlı kullanıcıya ait süresi dolan herhangi bir ödev bulunmuyor.",
+			"quiz": "Sınav",
+			"today": "Bugün",
+			"tomorrow": "Yarın",
+			"viewAllAssignments": "Tüm İşleri Görüntüle"
 		}
 	};
 </script>

--- a/lang/zh-tw.html
+++ b/lang/zh-tw.html
@@ -2,7 +2,7 @@
 
 <script>
 	/* eslint quotes: ["error", "double"] */
-	'use strict';
+	"use strict";
 
 	window.D2L = window.D2L || {};
 	window.D2L.UpcomingAssessments = window.D2L.UpcomingAssessments || {};

--- a/lang/zh-tw.html
+++ b/lang/zh-tw.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 
 <script>
+	/* eslint quotes: ["error", "double"] */
 	'use strict';
 
 	window.D2L = window.D2L || {};
@@ -13,26 +14,26 @@
 	*/
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangZhTwBehavior = {
 		zhTw: {
-			'activityComplete': 'Complete',
-			'activityDueToday': 'Due Today',
-			'activityEnded': 'Closed',
-			'activityOverdue': 'Overdue',
-			'assignment': 'Assignment',
-			'closeSimpleOverlayText': '返回儀表板',
-			'closeSimpleOverlayTextMobile': '儀表板',
-			'currentPeriod': '{startDate} - {endDate}',
-			'dueDateShort': '截止於 {dueDate}',
-			'dueDateLongImminent': '{prefix}：{dueDate}',
-			'endDateShort': 'Ends {endDate}',
-			'errorMessage': '載入此 Widget 時似乎發生問題。我們會盡快修復，使其恢復運作。',
-			'goNextText': 'next',
-			'goPreviousText': 'previous',
-			'noAssessmentsInThisTimeFrame': '{userName} 現階段沒有任何要截止的作業。',
-			'noUpcomingAssessments': '{userName} 沒有任何近期作業。',
-			'quiz': 'Quiz',
-			'today': '今天',
-			'tomorrow': '明天',
-			'viewAllAssignments': '檢視所有作業'
+			"activityComplete": "完成",
+			"activityDueToday": "今天截止",
+			"activityEnded": "Closed",
+			"activityOverdue": "逾期",
+			"assignment": "作業",
+			"closeSimpleOverlayText": "返回儀表板",
+			"closeSimpleOverlayTextMobile": "儀表板",
+			"currentPeriod": "{startDate} - {endDate}",
+			"dueDateShort": "截止於 {dueDate}",
+			"dueDateLongImminent": "{prefix}：{dueDate}",
+			"endDateShort": "結束於 {endDate}",
+			"errorMessage": "載入此 Widget 時似乎發生問題。我們正在著手處理，並將儘速修復。",
+			"goNextText": "下一個",
+			"goPreviousText": "上一個",
+			"noAssessmentsInThisTimeFrame": "{userName} 現階段沒有任何將要截止的作業。",
+			"noUpcomingAssessments": "{userName} 接下來 2 週沒有任何將要截止的作業。",
+			"quiz": "測驗",
+			"today": "今天",
+			"tomorrow": "明天",
+			"viewAllAssignments": "檢視所有作業"
 		}
 	};
 </script>

--- a/lang/zh.html
+++ b/lang/zh.html
@@ -2,7 +2,7 @@
 
 <script>
 	/* eslint quotes: ["error", "double"] */
-	'use strict';
+	"use strict";
 
 	window.D2L = window.D2L || {};
 	window.D2L.UpcomingAssessments = window.D2L.UpcomingAssessments || {};

--- a/lang/zh.html
+++ b/lang/zh.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 
 <script>
+	/* eslint quotes: ["error", "double"] */
 	'use strict';
 
 	window.D2L = window.D2L || {};
@@ -13,26 +14,26 @@
 	*/
 	window.D2L.UpcomingAssessments.LocalizeBehavior.LangZhBehavior = {
 		zh: {
-			'activityComplete': 'Complete',
-			'activityDueToday': 'Due Today',
-			'activityEnded': 'Closed',
-			'activityOverdue': 'Overdue',
-			'assignment': 'Assignment',
-			'closeSimpleOverlayText': '返回仪表板',
-			'closeSimpleOverlayTextMobile': '仪表板',
-			'currentPeriod': '{startDate} - {endDate}',
-			'dueDateShort': '截止 {dueDate}',
-			'dueDateLongImminent': '{prefix}：{dueDate}',
-			'endDateShort': 'Ends {endDate}',
-			'errorMessage': '加载本微件时出错了。我们正在努力解决，将尽快使其恢复正常。',
-			'goNextText': 'next',
-			'goPreviousText': 'previous',
-			'noAssessmentsInThisTimeFrame': '{userName} 无任何在此时间段到期的作业。',
-			'noUpcomingAssessments': '{userName} 无任何即将分配的作业。',
-			'quiz': 'Quiz',
-			'today': '今天',
-			'tomorrow': '明天',
-			'viewAllAssignments': '查看所有作业'
+			"activityComplete": "完成",
+			"activityDueToday": "今天过期",
+			"activityEnded": "Closed",
+			"activityOverdue": "过期",
+			"assignment": "作业",
+			"closeSimpleOverlayText": "返回仪表板",
+			"closeSimpleOverlayTextMobile": "仪表板",
+			"currentPeriod": "{startDate} - {endDate}",
+			"dueDateShort": "截止日期：{dueDate}",
+			"dueDateLongImminent": "{prefix}：{dueDate}",
+			"endDateShort": "结束日期：{endDate}",
+			"errorMessage": "加载此微件时似乎出现问题。我们正在解决，将会尽快使其恢复正常。",
+			"goNextText": "下一个",
+			"goPreviousText": "上一个",
+			"noAssessmentsInThisTimeFrame": "{userName} 无任何在此时间段到期的作业。",
+			"noUpcomingAssessments": "{userName} 无任何在未来 2 周内到期的作业。",
+			"quiz": "测验",
+			"today": "今天",
+			"tomorrow": "明天",
+			"viewAllAssignments": "查看所有作业"
 		}
 	};
 </script>


### PR DESCRIPTION
- Using double quotes instead of single. This makes it consistent with parent-portal-ui.
- Looks like we did not send "activityEnded" term for translation so it continues to be in English. We can live with it for this release.