### PR TITLE
DE27639 - Reset error state whenever we load new info

### DIFF
--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../d2l-colors/d2l-colors.html">
 <link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../../d2l-intl/d2l-intl.html">
 <link rel="import" href="../../d2l-link/d2l-link.html">
@@ -9,7 +10,6 @@
 <link rel="import" href="../behaviors/d2l-upcoming-assessments-behavior.html">
 <link rel="import" href="../behaviors/date-behavior.html">
 <link rel="import" href="../behaviors/localize-behavior.html">
-<link rel="import" href="../../d2l-colors/d2l-colors.html">
 <link rel="import" href="d2l-all-assessments-list.html">
 <link rel="import" href="d2l-assessments-list.html">
 
@@ -255,6 +255,7 @@
 			_debounceTime: 20,
 
 			_getInfo: function() {
+				this._showError = false;
 				var self = this;
 
 				return this._fetchEntity(this.userUrl, this.getToken)


### PR DESCRIPTION
Previously, if the widget errored out for one child, and then the parent switched children, the widget would remain in an error state. Simple fix, reset to be non-errored before we fetch a different child's data.

Also replaced the commented-out tests with some new, less-commented-out ones.

This isn't a full fix for DE27639, but it's part of what we're seeing in that.