### PR TITLE
Us88845 week selection

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
     "d2l-colors": "^2.2.3",
-    "d2l-date-picker": "^0.0.12",
+    "d2l-date-picker": "~0.0.12",
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^2.4.0",
     "d2l-icons": "^3.1.2",
     "d2l-intl": "^0.4.1",

--- a/bower.json
+++ b/bower.json
@@ -14,13 +14,18 @@
     "d2l-simple-overlay": "Brightspace/simple-overlay#1.1.0",
     "d2l-typography": "^5.3.0",
     "fetch": "^2.0.3",
+    "iron-a11y-keys": "^1.0.9",
     "iron-icon": "^1.0.12",
     "polymer": "Polymer/polymer#^1.9.2",
-    "vaadin-date-picker": "^2.0.2"
+    "vaadin-date-picker": "~1.2.3"
   },
   "devDependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
     "d2l-demo-template": "~0.0.11",
     "web-component-tester": "^6.1.3"
+  },
+  "resolutions": {
+    "d2l-polymer-behaviors": "^1.0.0",
+    "d2l-offscreen": "^2.2.5"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
     "d2l-colors": "^2.2.3",
+    "d2l-date-picker": "^0.0.12",
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^2.4.0",
     "d2l-icons": "^3.1.2",
     "d2l-intl": "^0.4.1",

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,8 @@
     "d2l-typography": "^5.3.0",
     "fetch": "^2.0.3",
     "iron-icon": "^1.0.12",
-    "polymer": "Polymer/polymer#^1.9.2"
+    "polymer": "Polymer/polymer#^1.9.2",
+    "vaadin-date-picker": "^2.0.2"
   },
   "devDependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",

--- a/components/d2l-all-assessments-list.html
+++ b/components/d2l-all-assessments-list.html
@@ -85,8 +85,8 @@
 				}
 
 				var dates = new Map();
-				var start = (new Date(this.periodStart)).setHours(0);
-				var end = (new Date(this.periodEnd)).setHours(0);
+				var start = this.periodStart;
+				var end = this.periodEnd;
 
 				for (var i = 0; i < assessmentItems.length; i++) {
 					var item = assessmentItems[i];

--- a/components/d2l-date-dropdown.html
+++ b/components/d2l-date-dropdown.html
@@ -29,7 +29,7 @@
 					--vaadin-date-picker-overlay: {
 						font-family: inherit;
 						max-height: 355px;
-						margin-top: -10px;
+						margin-top: 0;
 						border-radius: 5px;
 						border: 1px solid var(--d2l-color-mica);
 						opacity: 0;
@@ -80,7 +80,7 @@
 					z-index: 10000;
 					display: inline-block;
 					opacity: 0;
-					top: -20px;
+					top: -10px;
 				}
 
 				:host-context([dir="rtl"]) .d2l-dropdown-content-pointer {
@@ -176,7 +176,7 @@
 				var self = this;
 				this.addEventListener('iron-overlay-opened', function() {
 					self._opened = true;
-					self.$$('vaadin-date-picker-light').customStyle['--vaadin-date-picker-overlay'] = 'font-family: inherit; max-height: 355px; margin-top: -10px; border-radius: 5px; border: 1px solid var(--d2l-color-mica); transition: all 200ms cubic-bezier(.75, 0, 1, 1); opacity:1; transform: translateY(20px);';
+					self.$$('vaadin-date-picker-light').customStyle['--vaadin-date-picker-overlay'] = 'font-family: inherit; max-height: 355px; margin-top: 0px; border-radius: 5px; border: 1px solid var(--d2l-color-mica); transition: all 300ms ease; opacity:1; transform: translateY(10px);';
 					self.$$('vaadin-date-picker-light').updateStyles();
 				});
 
@@ -186,7 +186,7 @@
 
 				this.addEventListener('iron-overlay-closed', function() {
 					self._opened = false;
-					self.$$('vaadin-date-picker-light').customStyle['--vaadin-date-picker-overlay'] = 'font-family: inherit; max-height: 355px; margin-top: -10px; border-radius: 5px; border: 1px solid var(--d2l-color-mica); opacity:0;';
+					self.$$('vaadin-date-picker-light').customStyle['--vaadin-date-picker-overlay'] = 'font-family: inherit; max-height: 355px; margin-top: 0px; border-radius: 5px; border: 1px solid var(--d2l-color-mica); opacity:0;';
 					self.$$('vaadin-date-picker-light').updateStyles();
 				});
 			},
@@ -194,8 +194,8 @@
 				var pointer = this.$$('.d2l-dropdown-content-pointer');
 
 				if (opened && !smallScreen) {
-					pointer.style.transition = 'all 200ms cubic-bezier(.75, 0, 1, 1)';
-					pointer.style.transform = 'translateY(20px)';
+					pointer.style.transition = 'all 300ms ease';
+					pointer.style.transform = 'translateY(10px)';
 					pointer.style.opacity = 1;
 				} else {
 					pointer.style.transition = '';

--- a/components/d2l-date-dropdown.html
+++ b/components/d2l-date-dropdown.html
@@ -18,6 +18,7 @@
 				}
 
 				vaadin-date-picker-light {
+					height: 28px;
 					--primary-color: var(--d2l-color-celestine);
 					--light-primary-color: var(--d2l-color-celestine-plus-1);
 					--dark-theme-background-color: var(--d2l-color-ferrite);
@@ -27,6 +28,9 @@
 					--vaadin-date-picker-overlay: {
 						font-family: inherit;
 						max-height: 355px;
+						margin-top: 10px;
+						border-radius: 5px;
+						border: 1px solid var(--d2l-color-mica);
 					};
 					--vaadin-date-picker-yearscroller: {
 						font-family: inherit;
@@ -67,20 +71,46 @@
 					padding-left: 7px;
 					padding-right: 0px;
 				}
+
+				.d2l-dropdown-content-pointer {
+					position: relative;
+					clip: rect(-5px, 21px, 8px, -3px);
+					left: calc(50% - 7px);
+					z-index: 10000;
+					display: none;
+				}
+
+				.d2l-dropdown-content-pointer > div {
+					background-color: #ffffff;
+					border: 1px solid var(--d2l-color-mica);
+					border-radius: 0.1rem;
+					border-right: hidden;
+					border-bottom: hidden;
+					box-shadow: -4px -4px 12px -5px rgba(86, 90, 92, .2);
+					height: 16px;
+					width: 16px;
+					transform: rotate(45deg);
+					-webkit-transform: rotate(45deg);
+				}
 			</style>
 		</custom-style>
 
 		<vaadin-date-picker-light value="{{value}}" on-value-changed="handleValueChanged" attr-for-value="value">
 			<iron-a11y-keys target="[[_target]]" keys="enter" on-keys-pressed="_onEnter"></iron-a11y-keys>
 			<iron-a11y-keys target="[[_target]]" keys="up down" on-keys-pressed="_onUpDown"></iron-a11y-keys>
-			<a
-				is="d2l-link"
-				on-focus="_handleFocus"
-				on-tap="_handleTap"
-				class="input">
-				<span class="currentPeriod">[[currentPeriodText]]</span>
-				<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
-			</a>
+			<div class="input">
+				<a
+					is="d2l-link"
+					on-focus="_handleFocus"
+					on-tap="_handleTap">
+					<span class="currentPeriod">[[currentPeriodText]]</span>
+					<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
+				</a>
+				<div class="d2l-dropdown-content-pointer">
+					<div></div>
+				</div>
+			</div>
+
 		</vaadin-date-picker-light>
 	</template>
 
@@ -113,17 +143,47 @@
 					type: Number,
 					value: 0
 				},
+				_opened: {
+					type: Boolean,
+					value: false
+				},
+				_smallScreen: {
+					type: Boolean,
+					value: false
+				},
 				currentPeriodText: String
 			},
 			observers: [
 				'_localeChanged( locale )',
-				'_updateDatePickeri18n( locale, localize, dateFormat, firstDayOfWeek )'
+				'_updateDatePickeri18n( locale, localize, dateFormat, firstDayOfWeek )',
+				'_showPointer( _smallScreen, _opened )'
 			],
 			ready: function() {
 				this._target = this.$$('a');
+				var mql = window.matchMedia('(max-width: 420px)');
+				mql.addListener(this._mobileBreakpointListener.bind(this));
+
+				var self = this;
+				this.addEventListener('iron-overlay-opened', function() {
+					self._opened = true;
+				});
+
 				this.addEventListener('iron-overlay-canceled', function(e) {
 					e.stopPropagation();
 				});
+
+				this.addEventListener('iron-overlay-closed', function() {
+					self._opened = false;
+				});
+			},
+			_showPointer: function(smallScreen, opened) {
+				var pointer = this.$$('.d2l-dropdown-content-pointer');
+
+				if (opened && !smallScreen) {
+					pointer.style.display = 'inline-block';
+				} else {
+					pointer.style.display = 'none';
+				}
 			},
 			handleValueChanged: function(e, detail) {
 				if (detail.value) {
@@ -226,6 +286,13 @@
 					}
 				}.bind(this));
 				return obj1;
+			},
+			_mobileBreakpointListener: function(mqlevent) {
+				if (mqlevent.matches) {
+					this._smallScreen = true;
+				} else {
+					this._smallScreen = false;
+				}
 			}
 		});
 	</script>

--- a/components/d2l-date-dropdown.html
+++ b/components/d2l-date-dropdown.html
@@ -118,7 +118,7 @@
 	</template>
 
 	<script>
-	'use strict';
+		'use strict';
 
 		Polymer({
 			is: 'd2l-date-dropdown',
@@ -132,7 +132,7 @@
 				type: String
 			},
 			behaviors: [
-				window.D2L.UpcomingAssessments.LocalizeBehavior,
+				window.D2L.UpcomingAssessments.LocalizeBehavior
 			],
 			properties: {
 				placeholder: {
@@ -192,7 +192,14 @@
 				}
 			},
 			handleValueChanged: function(e, detail) {
-				this.fire('d2l-date-picker-value-changed', e, detail);
+				if (detail.value) {
+					var dateInfo = detail.value.split(/\s*\-\s*/g);
+					var year = dateInfo[0];
+					var month = dateInfo[1] - 1;
+					var date = dateInfo[2];
+					var changedDate = new Date(year, month, date);
+					this.fire('d2l-date-picker-value-changed', { date: changedDate });
+				}
 			},
 			_handleTap: function() {
 				var datepicker = this.$$('vaadin-date-picker-light');
@@ -218,7 +225,6 @@
 				}
 			},
 			focus: function() {
-				var thing = this.$$('a');
 				this.$$('a').focus();
 			},
 			_handleFocus: function() {

--- a/components/d2l-date-dropdown.html
+++ b/components/d2l-date-dropdown.html
@@ -83,6 +83,16 @@
 					top: -10px;
 				}
 
+				@media (min-width: 420px) and (min-height: 420px) {
+					.d2l-dropdown-content-pointer.opened {
+						opacity: 1;
+						transition-property: opacity, transform;
+						transition-duration: 300ms;
+						transition-timing-function: ease;
+						transform: translateY(10px);
+					}
+				}
+
 				:host-context([dir="rtl"]) .d2l-dropdown-content-pointer {
 					left: 0;
 					right: calc(50% - 7px);
@@ -153,30 +163,30 @@
 					type: Number,
 					value: 0
 				},
-				_opened: {
-					type: Boolean,
-					value: false
-				},
-				_smallScreen: {
-					type: Boolean,
-					value: false
-				},
 				currentPeriodText: String
 			},
 			observers: [
 				'_localeChanged( locale )',
-				'_updateDatePickeri18n( locale, localize, dateFormat, firstDayOfWeek )',
-				'_showPointer( _smallScreen, _opened )'
+				'_updateDatePickeri18n( locale, localize, dateFormat, firstDayOfWeek )'
 			],
 			ready: function() {
 				this._target = this.$$('a');
-				var mql = window.matchMedia('(max-width: 420px)');
-				mql.addListener(this._mobileBreakpointListener.bind(this));
 
 				var self = this;
+				var pointer = this.$$('.d2l-dropdown-content-pointer');
+
 				this.addEventListener('iron-overlay-opened', function() {
-					self._opened = true;
-					self.$$('vaadin-date-picker-light').customStyle['--vaadin-date-picker-overlay'] = 'font-family: inherit; max-height: 355px; margin-top: 0px; border-radius: 5px; border: 1px solid var(--d2l-color-mica); transition: all 300ms ease; opacity:1; transform: translateY(10px);';
+					pointer.classList.add('opened');
+					self.$$('vaadin-date-picker-light').customStyle['--vaadin-date-picker-overlay'] = 'font-family: inherit;\
+						max-height: 355px;\
+						margin-top: 0px;\
+						border-radius: 5px;\
+						border: 1px solid var(--d2l-color-mica);\
+						transition-property: opacity, transform;\
+						transition-duration: 300ms;\
+						transition-timing-function: ease;\
+						opacity:1;\
+						transform: translateY(10px);';
 					self.$$('vaadin-date-picker-light').updateStyles();
 				});
 
@@ -185,23 +195,15 @@
 				});
 
 				this.addEventListener('iron-overlay-closed', function() {
-					self._opened = false;
-					self.$$('vaadin-date-picker-light').customStyle['--vaadin-date-picker-overlay'] = 'font-family: inherit; max-height: 355px; margin-top: 0px; border-radius: 5px; border: 1px solid var(--d2l-color-mica); opacity:0;';
+					pointer.classList.remove('opened');
+					self.$$('vaadin-date-picker-light').customStyle['--vaadin-date-picker-overlay'] = 'font-family: inherit;\
+						max-height: 355px;\
+						margin-top: 0px;\
+						border-radius: 5px;\
+						border: 1px solid var(--d2l-color-mica);\
+						opacity:0;';
 					self.$$('vaadin-date-picker-light').updateStyles();
 				});
-			},
-			_showPointer: function(smallScreen, opened) {
-				var pointer = this.$$('.d2l-dropdown-content-pointer');
-
-				if (opened && !smallScreen) {
-					pointer.style.transition = 'all 300ms ease';
-					pointer.style.transform = 'translateY(10px)';
-					pointer.style.opacity = 1;
-				} else {
-					pointer.style.transition = '';
-					pointer.style.transform = '';
-					pointer.style.opacity = 0;
-				}
 			},
 			handleValueChanged: function(e, detail) {
 				if (detail.value) {
@@ -304,13 +306,6 @@
 					}
 				}.bind(this));
 				return obj1;
-			},
-			_mobileBreakpointListener: function(mqlevent) {
-				if (mqlevent.matches) {
-					this._smallScreen = true;
-				} else {
-					this._smallScreen = false;
-				}
 			}
 		});
 	</script>

--- a/components/d2l-date-dropdown.html
+++ b/components/d2l-date-dropdown.html
@@ -29,7 +29,7 @@
 					--vaadin-date-picker-overlay: {
 						font-family: inherit;
 						max-height: 355px;
-						margin-top: 10px;
+						margin-top: -10px;
 						border-radius: 5px;
 						border: 1px solid var(--d2l-color-mica);
 						opacity: 0;
@@ -80,6 +80,13 @@
 					z-index: 10000;
 					display: inline-block;
 					opacity: 0;
+					top: -20px;
+				}
+
+				:host-context([dir="rtl"]) .d2l-dropdown-content-pointer {
+					left: 0;
+					right: calc(50% - 7px);
+					margin-top: 3px;
 				}
 
 				.d2l-dropdown-content-pointer > div {
@@ -169,7 +176,7 @@
 				var self = this;
 				this.addEventListener('iron-overlay-opened', function() {
 					self._opened = true;
-					self.$$('vaadin-date-picker-light').customStyle['--vaadin-date-picker-overlay'] = 'font-family: inherit; max-height: 355px; margin-top: 10px; border-radius: 5px; border: 1px solid var(--d2l-color-mica); transition: all 200ms cubic-bezier(.75, 0, 1, 1); opacity:1;';
+					self.$$('vaadin-date-picker-light').customStyle['--vaadin-date-picker-overlay'] = 'font-family: inherit; max-height: 355px; margin-top: -10px; border-radius: 5px; border: 1px solid var(--d2l-color-mica); transition: all 200ms cubic-bezier(.75, 0, 1, 1); opacity:1; transform: translateY(20px);';
 					self.$$('vaadin-date-picker-light').updateStyles();
 				});
 
@@ -179,7 +186,7 @@
 
 				this.addEventListener('iron-overlay-closed', function() {
 					self._opened = false;
-					self.$$('vaadin-date-picker-light').customStyle['--vaadin-date-picker-overlay'] = 'font-family: inherit; max-height: 355px; margin-top: 10px; border-radius: 5px; border: 1px solid var(--d2l-color-mica); opacity:0;';
+					self.$$('vaadin-date-picker-light').customStyle['--vaadin-date-picker-overlay'] = 'font-family: inherit; max-height: 355px; margin-top: -10px; border-radius: 5px; border: 1px solid var(--d2l-color-mica); opacity:0;';
 					self.$$('vaadin-date-picker-light').updateStyles();
 				});
 			},
@@ -188,9 +195,11 @@
 
 				if (opened && !smallScreen) {
 					pointer.style.transition = 'all 200ms cubic-bezier(.75, 0, 1, 1)';
+					pointer.style.transform = 'translateY(20px)';
 					pointer.style.opacity = 1;
 				} else {
 					pointer.style.transition = '';
+					pointer.style.transform = '';
 					pointer.style.opacity = 0;
 				}
 			},

--- a/components/d2l-date-dropdown.html
+++ b/components/d2l-date-dropdown.html
@@ -3,11 +3,11 @@
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
 <link rel="import" href="../../iron-input/iron-input.html">
 <link rel="import" href="../../iron-a11y-keys/iron-a11y-keys.html">
-<link rel="import" href="../../d2l-time-picker/d2l-time-picker.html">
-<link rel="import" href="../../d2l-intl/d2l-intl.html">
 <link rel="import" href="../../d2l-offscreen/d2l-offscreen-shared-styles.html">
 <link rel="import" href="../../d2l-polymer-behaviors/d2l-id.html">
-<link rel="import" href="../behaviors/localize-behavior.html">
+<link rel="import" href="../../d2l-icons/d2l-icon.html">
+<link rel="import" href="../../d2l-icons/tier1-icons.html">
+<link rel="import" href="../../d2l-date-picker/localize-behavior.html">
 
 <dom-module id="d2l-date-dropdown">
 	<template>
@@ -16,18 +16,7 @@
 				:host {
 					display: block;
 				}
-				:host([hide-label]) > label,
-				.d2l-date-picker-description {
-					@apply --d2l-offscreen;
-				}
-				:host(:dir(rtl)) :host([hide-label]) > label,
-				:host(:dir(rtl)) .d2l-date-picker-description {
-					@apply --d2l-offscreen-rtl;
-				}
-				:host-context([dir="rtl"]) :host([hide-label]) > label,
-				:host-context([dir="rtl"]) .d2l-date-picker-description {
-					@apply --d2l-offscreen-rtl;
-				}
+
 				vaadin-date-picker-light {
 					--primary-color: var(--d2l-color-celestine);
 					--light-primary-color: var(--d2l-color-celestine-plus-1);
@@ -58,12 +47,6 @@
 						font-family: inherit;
 					};
 				}
-				label {
-					@apply --d2l-date-picker-label;
-				}
-				input {
-					display: none;
-				}
 
 				span {
 					padding-right: 7px;
@@ -81,29 +64,17 @@
 				}
 
 				:host-context([dir="rtl"]) span {
-					padding-left: 0px;
-					padding-right: 7px;
+					padding-left: 7px;
+					padding-right: 0px;
 				}
 			</style>
 		</custom-style>
 
-		<label id="[[_labelId]]">{{label}}</label>
 		<vaadin-date-picker-light min="[[min]]" max="[[max]]" value="{{value}}" on-value-changed="handleValueChanged" attr-for-value="value">
 			<iron-a11y-keys target="[[_target]]" keys="enter" on-keys-pressed="_onEnter"></iron-a11y-keys>
 			<iron-a11y-keys target="[[_target]]" keys="up down" on-keys-pressed="_onUpDown"></iron-a11y-keys>
-			<iron-input>
-				<input
-					on-tap="_handleTap"
-					placeholder="{{placeholder}}"
-					class="d2l-input"
-					is="iron-input"
-					type="text"
-					on-focus="_handleFocus"
-					aria-describedby$="[[_descriptionId]]"
-					aria-labelledby$="[[_labelId]]"
-					style="display:none;"
-				>
-				</input>
+			<div>
+				<input is="iron-input" style="display:none;"></input>
 				<a
 					is="d2l-link"
 					on-focus="_handleFocus"
@@ -112,8 +83,7 @@
 					<span class="currentPeriod">[[currentPeriodText]]</span>
 					<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
 				</a>
-				<!-- <div id="[[_descriptionId]]" class="d2l-date-picker-description" >{{description}}</div> -->
-			</iron-input>
+			</div>
 		</vaadin-date-picker-light>
 	</template>
 
@@ -125,19 +95,10 @@
 			_target: {
 				type: Object
 			},
-			_descriptionId: {
-				type: String
-			},
-			_labelId: {
-				type: String
-			},
 			behaviors: [
-				window.D2L.UpcomingAssessments.LocalizeBehavior
+				window.D2L.PolymerBehaviors.DatePicker.LocalizeBehavior
 			],
 			properties: {
-				placeholder: {
-					type: String
-				},
 				min: {
 					type: String
 				},
@@ -148,17 +109,6 @@
 					type: String,
 					reflectToAttribute: true,
 					notify: true
-				},
-				label: {
-					type: String
-				},
-				hideLabel: {
-					type: Boolean,
-					value: false,
-					reflectToAttribute: true
-				},
-				description:{
-					type: String
 				},
 				locale: {
 					type: String,
@@ -175,15 +125,14 @@
 				currentPeriodText: String
 			},
 			observers: [
-				'_localeChanged( locale )'
+				'_localeChanged( locale )',
+				'_updateDatePickeri18n( locale, localize, dateFormat, firstDayOfWeek )'
 			],
 			ready: function() {
 				this._target = this.$$('a');
 				this.addEventListener('iron-overlay-canceled', function(e) {
 					e.stopPropagation();
 				});
-				// this._labelId = D2L.Id.getUniqueId();
-				// this._descriptionId = D2L.Id.getUniqueId();
 			},
 			attached: function() {
 				var buttons = document.getElementsByClassName('vaadin-date-picker-overlay paper-button-0');
@@ -239,6 +188,44 @@
 			},
 			_localeChanged: function( locale ) {
 				this.language = locale;
+			},
+			_updateDatePickeri18n: function() {
+				var locale = window.d2lIntl.LocaleProvider(this.locale);
+				var dateFormatOverride = this.dateFormat ? {
+					locale: {
+						date: {
+							formats: {
+								dateFormats: {
+									short: this.dateFormat
+								}
+							}
+						}
+					}
+				} : {};
+				var formatter = new window.d2lIntl.DateTimeFormat( this.locale, dateFormatOverride );
+				var parser = new window.d2lIntl.DateTimeParse( this.locale, dateFormatOverride );
+				var datePicker = this.$$('vaadin-date-picker-light');
+				var localeOverrides = {
+					monthNames: locale.date.calendar.months.long,
+					weekdays: locale.date.calendar.days.long,
+					weekdaysShort: locale.date.calendar.days.short,
+					firstDayOfWeek: this.firstDayOfWeek ? this.firstDayOfWeek : locale.date.calendar.firstDayOfWeek,
+					today: this.localize('today'),
+					cancel: this.localize('cancel'),
+					formatDate: function( date ) {
+						return formatter.formatDate( date );
+					},
+					parseDate: function( dateString ) {
+						try {
+							return parser.parseDate( dateString );
+						} catch (exception) {
+							return null;
+						}
+					}
+				};
+				var datePickerLocale = this._merge(datePicker.i18n, localeOverrides);
+				datePicker.i18n = {}; // reassign to have Polymer refresh
+				datePicker.i18n = datePickerLocale;
 			},
 			_merge: function(obj1, obj2) {
 				if (obj2 === undefined || obj2 === null || typeof(obj2) !== 'object') {

--- a/components/d2l-date-dropdown.html
+++ b/components/d2l-date-dropdown.html
@@ -19,10 +19,11 @@
 
 				vaadin-date-picker-light {
 					height: 28px;
+
 					--primary-color: var(--d2l-color-celestine);
 					--light-primary-color: var(--d2l-color-celestine-plus-1);
 					--dark-theme-background-color: var(--d2l-color-ferrite);
-					--dark-theme-secondary-color: #ffffff;
+					--dark-theme-secondary-color: var(--d2l-color-white);
 					--primary-text-color: var(--d2l-color-ferrite);
 					--secondary-text-color: var(--d2l-color-tungsten);
 					--vaadin-date-picker-overlay: {
@@ -31,6 +32,7 @@
 						margin-top: 10px;
 						border-radius: 5px;
 						border: 1px solid var(--d2l-color-mica);
+						opacity: 0;
 					};
 					--vaadin-date-picker-yearscroller: {
 						font-family: inherit;
@@ -62,8 +64,7 @@
 					align-items: center;
 				}
 
-				a:hover,
-				a:focus {
+				a:hover {
 					text-decoration: none;
 				}
 
@@ -77,11 +78,12 @@
 					clip: rect(-5px, 21px, 8px, -3px);
 					left: calc(50% - 7px);
 					z-index: 10000;
-					display: none;
+					display: inline-block;
+					opacity: 0;
 				}
 
 				.d2l-dropdown-content-pointer > div {
-					background-color: #ffffff;
+					background-color: var(--d2l-color-white);
 					border: 1px solid var(--d2l-color-mica);
 					border-radius: 0.1rem;
 					border-right: hidden;
@@ -100,6 +102,7 @@
 			<iron-a11y-keys target="[[_target]]" keys="up down" on-keys-pressed="_onUpDown"></iron-a11y-keys>
 			<div class="input">
 				<a
+					href="javascript:void(0);"
 					is="d2l-link"
 					on-focus="_handleFocus"
 					on-tap="_handleTap">
@@ -166,6 +169,8 @@
 				var self = this;
 				this.addEventListener('iron-overlay-opened', function() {
 					self._opened = true;
+					self.$$('vaadin-date-picker-light').customStyle['--vaadin-date-picker-overlay'] = 'font-family: inherit; max-height: 355px; margin-top: 10px; border-radius: 5px; border: 1px solid var(--d2l-color-mica); transition: all 200ms cubic-bezier(.75, 0, 1, 1); opacity:1;';
+					self.$$('vaadin-date-picker-light').updateStyles();
 				});
 
 				this.addEventListener('iron-overlay-canceled', function(e) {
@@ -174,15 +179,19 @@
 
 				this.addEventListener('iron-overlay-closed', function() {
 					self._opened = false;
+					self.$$('vaadin-date-picker-light').customStyle['--vaadin-date-picker-overlay'] = 'font-family: inherit; max-height: 355px; margin-top: 10px; border-radius: 5px; border: 1px solid var(--d2l-color-mica); opacity:0;';
+					self.$$('vaadin-date-picker-light').updateStyles();
 				});
 			},
 			_showPointer: function(smallScreen, opened) {
 				var pointer = this.$$('.d2l-dropdown-content-pointer');
 
 				if (opened && !smallScreen) {
-					pointer.style.display = 'inline-block';
+					pointer.style.transition = 'all 200ms cubic-bezier(.75, 0, 1, 1)';
+					pointer.style.opacity = 1;
 				} else {
-					pointer.style.display = 'none';
+					pointer.style.transition = '';
+					pointer.style.opacity = 0;
 				}
 			},
 			handleValueChanged: function(e, detail) {

--- a/components/d2l-date-dropdown.html
+++ b/components/d2l-date-dropdown.html
@@ -1,0 +1,254 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../vaadin-date-picker/vaadin-date-picker-light.html">
+<link rel="import" href="../../d2l-colors/d2l-colors.html">
+<link rel="import" href="../../iron-input/iron-input.html">
+<link rel="import" href="../../iron-a11y-keys/iron-a11y-keys.html">
+<link rel="import" href="../../d2l-time-picker/d2l-time-picker.html">
+<link rel="import" href="../../d2l-intl/d2l-intl.html">
+<link rel="import" href="../../d2l-offscreen/d2l-offscreen-shared-styles.html">
+<link rel="import" href="../../d2l-polymer-behaviors/d2l-id.html">
+<link rel="import" href="../behaviors/localize-behavior.html">
+
+<dom-module id="d2l-date-dropdown">
+	<template>
+		<custom-style>
+			<style is="custom-style" include="d2l-input-styles d2l-offscreen-shared-styles">
+				:host {
+					display: block;
+				}
+				:host([hide-label]) > label,
+				.d2l-date-picker-description {
+					@apply --d2l-offscreen;
+				}
+				:host(:dir(rtl)) :host([hide-label]) > label,
+				:host(:dir(rtl)) .d2l-date-picker-description {
+					@apply --d2l-offscreen-rtl;
+				}
+				:host-context([dir="rtl"]) :host([hide-label]) > label,
+				:host-context([dir="rtl"]) .d2l-date-picker-description {
+					@apply --d2l-offscreen-rtl;
+				}
+				vaadin-date-picker-light {
+					--primary-color: var(--d2l-color-celestine);
+					--light-primary-color: var(--d2l-color-celestine-plus-1);
+					--dark-theme-background-color: var(--d2l-color-ferrite);
+					--dark-theme-secondary-color: #ffffff;
+					--primary-text-color: var(--d2l-color-ferrite);
+					--secondary-text-color: var(--d2l-color-tungsten);
+					--vaadin-date-picker-overlay: {
+						font-family: inherit;
+						max-height: 355px;
+					};
+					--vaadin-date-picker-yearscroller: {
+						font-family: inherit;
+					};
+					--vaadin-date-picker-header: {
+						font-family: inherit;
+					};
+					--vaadin-date-picker-calendar-title: {
+						font-family: inherit;
+					};
+					--vaadin-date-picker-calendar-cell: {
+						font-family: inherit;
+					};
+					--vaadin-date-picker-footer: {
+						font-family: inherit;
+					};
+					--vaadin-date-picker-calendar: {
+						font-family: inherit;
+					};
+				}
+				label {
+					@apply --d2l-date-picker-label;
+				}
+				input {
+					display: none;
+				}
+
+				span {
+					padding-right: 7px;
+					color: var(--d2l-color-ferrite);
+				}
+
+				a {
+					display: flex;
+					align-items: center;
+				}
+
+				a:hover,
+				a:focus {
+					text-decoration: none;
+				}
+
+				:host-context([dir="rtl"]) span {
+					padding-left: 0px;
+					padding-right: 7px;
+				}
+			</style>
+		</custom-style>
+
+		<label id="[[_labelId]]">{{label}}</label>
+		<vaadin-date-picker-light min="[[min]]" max="[[max]]" value="{{value}}" on-value-changed="handleValueChanged" attr-for-value="value">
+			<iron-a11y-keys target="[[_target]]" keys="enter" on-keys-pressed="_onEnter"></iron-a11y-keys>
+			<iron-a11y-keys target="[[_target]]" keys="up down" on-keys-pressed="_onUpDown"></iron-a11y-keys>
+			<iron-input>
+				<input
+					on-tap="_handleTap"
+					placeholder="{{placeholder}}"
+					class="d2l-input"
+					is="iron-input"
+					type="text"
+					on-focus="_handleFocus"
+					aria-describedby$="[[_descriptionId]]"
+					aria-labelledby$="[[_labelId]]"
+					style="display:none;"
+				>
+				</input>
+				<a
+					is="d2l-link"
+					on-focus="_handleFocus"
+					on-tap="_handleTap"
+					class="currentPeriod">
+					<span class="currentPeriod">[[currentPeriodText]]</span>
+					<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
+				</a>
+				<!-- <div id="[[_descriptionId]]" class="d2l-date-picker-description" >{{description}}</div> -->
+			</iron-input>
+		</vaadin-date-picker-light>
+	</template>
+
+	<script>
+	'use strict';
+
+		Polymer({
+			is: 'd2l-date-dropdown',
+			_target: {
+				type: Object
+			},
+			_descriptionId: {
+				type: String
+			},
+			_labelId: {
+				type: String
+			},
+			behaviors: [
+				window.D2L.UpcomingAssessments.LocalizeBehavior,
+			],
+			properties: {
+				placeholder: {
+					type: String
+				},
+				min: {
+					type: String
+				},
+				max: {
+					type: String
+				},
+				value: {
+					type: String,
+					reflectToAttribute: true,
+					notify: true
+				},
+				label: {
+					type: String
+				},
+				hideLabel: {
+					type: Boolean,
+					value: false,
+					reflectToAttribute: true
+				},
+				description:{
+					type: String
+				},
+				locale: {
+					type: String,
+					value: 'en'
+				},
+				dateFormat: {
+					type: String,
+					value: ''
+				},
+				firstDayOfWeek: {
+					type: Number,
+					value: 0
+				},
+				currentPeriodText: String
+			},
+			observers: [
+				'_localeChanged( locale )'
+			],
+			ready: function() {
+				this._target = this.$$('a');
+				this.addEventListener('iron-overlay-canceled', function(e) {
+					e.stopPropagation();
+				});
+				// this._labelId = D2L.Id.getUniqueId();
+				// this._descriptionId = D2L.Id.getUniqueId();
+			},
+			attached: function() {
+				var buttons = document.getElementsByClassName('vaadin-date-picker-overlay paper-button-0');
+				for (var i = 0; i < buttons.length; i++) {
+					buttons[i].style.fontFamily = 'inherit';
+				}
+			},
+			handleValueChanged: function(e, detail) {
+				this.fire('d2l-date-picker-value-changed', e, detail);
+			},
+			_handleTap: function() {
+				var datepicker = this.$$('vaadin-date-picker-light');
+				if ( !datepicker.opened ) {
+					datepicker._focusOverlayOnOpen = true;
+				}
+			},
+			_onEnter: function(e) {
+				var datepicker = this.$$('vaadin-date-picker-light');
+				if ( !datepicker.opened ) {
+					// A better solution is to add a boolean to the 3rd party open function
+					datepicker._focusOverlayOnOpen = true;
+					datepicker.open();
+					e.detail.keyboardEvent.preventDefault();
+					e.detail.keyboardEvent.stopPropagation();
+				}
+			},
+			_onUpDown: function(e) {
+				var datepicker = this.$$('vaadin-date-picker-light');
+				if ( !datepicker.opened ) {
+					e.detail.keyboardEvent.preventDefault();
+					e.detail.keyboardEvent.stopPropagation();
+				}
+			},
+			focus: function() {
+				var thing = this.$$('a');
+				this.$$('a').focus();
+			},
+			_handleFocus: function() {
+				// in shady DOM the input's "focus" event does not bubble,
+				// so no need to fire it
+				if (!Polymer.Settings.useShadow) {
+					this.dispatchEvent( new CustomEvent(
+							'focus',
+							{bubbles: true, composed: false}
+						) );
+				}
+			},
+			_localeChanged: function( locale ) {
+				this.language = locale;
+			},
+			_merge: function(obj1, obj2) {
+				if (obj2 === undefined || obj2 === null || typeof(obj2) !== 'object') {
+					return obj1;
+				}
+				Object.keys(obj2).forEach( function(i) {
+					if (obj1.hasOwnProperty(i)) {
+						if (typeof(obj2[i]) === 'object' && typeof(obj1[i]) === 'object' ) {
+							this._merge(obj1[i], obj2[i]);
+						} else {
+							obj1[i] = obj2[i];
+						}
+					}
+				}.bind(this));
+				return obj1;
+			}
+		});
+	</script>
+</dom-module>

--- a/components/d2l-date-dropdown.html
+++ b/components/d2l-date-dropdown.html
@@ -1,18 +1,18 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../vaadin-date-picker/vaadin-date-picker-light.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
-<link rel="import" href="../../iron-input/iron-input.html">
 <link rel="import" href="../../iron-a11y-keys/iron-a11y-keys.html">
 <link rel="import" href="../../d2l-offscreen/d2l-offscreen-shared-styles.html">
 <link rel="import" href="../../d2l-polymer-behaviors/d2l-id.html">
 <link rel="import" href="../../d2l-icons/d2l-icon.html">
 <link rel="import" href="../../d2l-icons/tier1-icons.html">
 <link rel="import" href="../../d2l-date-picker/localize-behavior.html">
+<link rel="import" href="../../d2l-intl/d2l-intl.html">
 
 <dom-module id="d2l-date-dropdown">
 	<template>
 		<custom-style>
-			<style is="custom-style" include="d2l-input-styles d2l-offscreen-shared-styles">
+			<style is="custom-style" include="d2l-offscreen-shared-styles">
 				:host {
 					display: block;
 				}
@@ -70,20 +70,17 @@
 			</style>
 		</custom-style>
 
-		<vaadin-date-picker-light min="[[min]]" max="[[max]]" value="{{value}}" on-value-changed="handleValueChanged" attr-for-value="value">
+		<vaadin-date-picker-light value="{{value}}" on-value-changed="handleValueChanged" attr-for-value="value">
 			<iron-a11y-keys target="[[_target]]" keys="enter" on-keys-pressed="_onEnter"></iron-a11y-keys>
 			<iron-a11y-keys target="[[_target]]" keys="up down" on-keys-pressed="_onUpDown"></iron-a11y-keys>
-			<div>
-				<input is="iron-input" style="display:none;"></input>
-				<a
-					is="d2l-link"
-					on-focus="_handleFocus"
-					on-tap="_handleTap"
-					class="currentPeriod">
-					<span class="currentPeriod">[[currentPeriodText]]</span>
-					<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
-				</a>
-			</div>
+			<a
+				is="d2l-link"
+				on-focus="_handleFocus"
+				on-tap="_handleTap"
+				class="input">
+				<span class="currentPeriod">[[currentPeriodText]]</span>
+				<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
+			</a>
 		</vaadin-date-picker-light>
 	</template>
 
@@ -99,12 +96,6 @@
 				window.D2L.PolymerBehaviors.DatePicker.LocalizeBehavior
 			],
 			properties: {
-				min: {
-					type: String
-				},
-				max: {
-					type: String
-				},
 				value: {
 					type: String,
 					reflectToAttribute: true,
@@ -134,12 +125,6 @@
 					e.stopPropagation();
 				});
 			},
-			attached: function() {
-				var buttons = document.getElementsByClassName('vaadin-date-picker-overlay paper-button-0');
-				for (var i = 0; i < buttons.length; i++) {
-					buttons[i].style.fontFamily = 'inherit';
-				}
-			},
 			handleValueChanged: function(e, detail) {
 				if (detail.value) {
 					var dateInfo = detail.value.split(/\s*\-\s*/g);
@@ -147,7 +132,7 @@
 					var month = dateInfo[1] - 1;
 					var date = dateInfo[2];
 					var changedDate = new Date(year, month, date);
-					this.fire('d2l-date-picker-value-changed', { date: changedDate });
+					this.fire('d2l-date-dropdown-value-changed', { date: changedDate });
 				}
 			},
 			_handleTap: function() {

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -1,4 +1,6 @@
 <link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../d2l-dropdown/d2l-dropdown.html">
+<link rel="import" href="../../d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../../d2l-intl/d2l-intl.html">
 <link rel="import" href="../../d2l-link/d2l-link.html">
@@ -44,6 +46,29 @@
 				padding-left: 7px;
 			}
 
+			.period-selection-container {
+				text-align: center;
+				margin-bottom: 10px;
+			}
+
+			.period-selection-container span {
+				padding-right: 7px;
+			}
+
+			.d2l-dropdown-opener {
+				display: flex;
+				align-items: center;
+			}
+
+			.d2l-dropdown-opener span {
+				color: var(--d2l-color-ferrite);
+			}
+
+			.d2l-dropdown-opener:hover,
+			.d2l-dropdown-opener:focus {
+				text-decoration: none;
+			}
+
 			:host-context([dir="rtl"]) h2 {
 				margin-left: 0px;
 				margin-right: 15px;
@@ -52,6 +77,11 @@
 			:host-context([dir="rtl"]) d2l-simple-overlay-close-button span {
 				padding-left: 0px;
 				padding-right: 7px;
+			}
+
+			:host-context([dir="rtl"]) .period-selection-container span {
+				padding-right: 0;
+				padding-left: 7px;
 			}
 
 			.error-message,
@@ -105,12 +135,6 @@
 				color: var(--d2l-color-celestuba);
 			}
 
-			.period-selection-container {
-				display: flex;
-				justify-content: space-between;
-				align-items: center;
-				margin-bottom: 10px;
-			}
 		</style>
 
 
@@ -154,9 +178,16 @@
 				</div>
 			</div>
 			 <div class="period-selection-container">
-				<a is="d2l-link" href="javascript:void(0);" on-tap="_goPrev" on-keypress="_keypressGoPrev">[[localize('goPreviousText')]]</a>
-				<div>[[_currentPeriodText]]</div>
-				<a is="d2l-link" href="javascript:void(0);" on-tap="_goNext" on-keypress="_keypressGoNext">[[localize('goNextText')]]</a>
+				 <d2l-dropdown>
+					 <a is="d2l-link" class="d2l-dropdown-opener">
+						 <span>[[_currentPeriodText]]</span>
+						 <d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
+					 </a>
+					 <d2l-dropdown-content align="start">
+						 <a is="d2l-link" href="javascript:void(0);" on-tap="_goPrev" on-keypress="_keypressGoPrev">[[localize('goPreviousText')]]</a>
+						 <a is="d2l-link" href="javascript:void(0);" on-tap="_goNext" on-keypress="_keypressGoNext">[[localize('goNextText')]]</a>
+					 </d2l-dropdown-content>
+				 </d2l-dropdown>
 			</div>
 			<template is="dom-if" if="[[_hasActivities(_allActivities)]]">
 				<d2l-all-assessments-list assessment-items=[[_allActivities]]></d2l-all-assessments-list>

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -1,6 +1,4 @@
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../d2l-dropdown/d2l-dropdown.html">
-<link rel="import" href="../../d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../../d2l-intl/d2l-intl.html">
 <link rel="import" href="../../d2l-link/d2l-link.html">
@@ -242,7 +240,7 @@
 			],
 
 			listeners: {
-				'd2l-date-picker-value-changed': '_onDateValueChanged'
+				'd2l-date-dropdown-value-changed': '_onDateValueChanged'
 			},
 
 			observers: [

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -226,7 +226,8 @@
 					value: null
 				},
 				_periodStart: String,
-				_periodEnd: String
+				_periodEnd: String,
+				_selectCustomDateRangeAction: Object
 			},
 
 			behaviors: [
@@ -235,6 +236,10 @@
 				window.D2L.UpcomingAssessments.LocalizeBehavior,
 				window.D2L.Hypermedia.HMConstantsBehavior
 			],
+
+			listeners: {
+				'd2l-date-picker-value-changed': '_onDateValueChanged'
+			},
 
 			observers: [
 				'_onApiConfigChanged(userUrl, getToken)'
@@ -325,9 +330,15 @@
 					});
 			},
 
-			_keypressGoPrev: function(e) {
-				if ( e.code === 'Space' || e.code === 'Enter' ) {
-					return this._goPrev(e);
+			_onDateValueChanged: function(e) {
+				if (e.detail.date && e.detail.date !== null) {
+					var parameters = this._getCustomDateRangeParameters(e.detail.date);
+					var periodUrl = this._createActionUrl(this._selectCustomDateRangeAction, parameters);
+					return this._loadActivitiesForPeriod(periodUrl)
+					.catch(function() {
+						self._showError = true;
+						self._userName = null;
+					});
 				}
 			},
 
@@ -339,12 +350,6 @@
 					});
 			},
 
-			_keypressGoNext: function(e) {
-				if ( e.code === 'Space' || e.code === 'Enter' ) {
-					return this._goNext(e);
-				}
-			},
-
 			_getCustomRangeAction: function(activitiesUrl) {
 				if (!activitiesUrl) {
 					return Promise.reject();
@@ -354,19 +359,24 @@
 
 				return this._fetchEntity(activitiesUrl, this.getToken, this.userUrl)
 					.then(function(activities) {
-						var parameters = self._getCustomDateRangeParameters();
+						var currentTime = new Date();
+						currentTime.setHours(0, 0, 0, 0);
+						var parameters = self._getCustomDateRangeParameters(currentTime);
 
 						var action = (activities.getActionByName(self.HypermediaActions.activities.selectCustomDateRange) || {});
+						self._selectCustomDateRangeAction = action;
 
 						return self._createActionUrl(action, parameters);
 					});
 			},
 
-			_getCustomDateRangeParameters: function() {
-				var currentTime = new Date();
-				var start = currentTime.toISOString();
-				var twoWeeksFromNow = new Date(currentTime.setDate(currentTime.getDate() + 14));
-				var end = twoWeeksFromNow.toISOString();
+			_getCustomDateRangeParameters: function(selectedDate) {
+				var day = selectedDate.getDay();
+				var startDate = new Date(selectedDate.setDate(selectedDate.getDate() - day));
+				var start = startDate.toISOString();
+				var twoWeeksFromStart = new Date(startDate.setDate(startDate.getDate() + 14));
+				twoWeeksFromStart.setHours(23, 59, 59, 999);
+				var end = twoWeeksFromStart.toISOString();
 
 				return {
 					start: start,

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -153,7 +153,11 @@
 				</div>
 			</div>
 			 <div class="period-selection-container">
-				 <d2l-date-dropdown current-period-text=[[_currentPeriodText]]></d2l-date-dropdown>
+				 <d2l-date-dropdown
+				 	current-period-text=[[_currentPeriodText]]
+					locale=[[locale]]
+					>
+				</d2l-date-dropdown>
 			</div>
 			<template is="dom-if" if="[[_hasActivities(_allActivities)]]">
 				<d2l-all-assessments-list
@@ -322,16 +326,8 @@
 				this.$['view-all-assignments-overlay'].open();
 			},
 
-			_goPrev: function() {
-				return this._loadActivitiesForPeriod(this._previousPeriodUrl)
-					.catch(function() {
-						self._showError = true;
-						self._userName = null;
-					});
-			},
-
 			_onDateValueChanged: function(e) {
-				if (e.detail.date && e.detail.date !== null) {
+				if (e.detail.date) {
 					var parameters = this._getCustomDateRangeParameters(e.detail.date);
 					var periodUrl = this._createActionUrl(this._selectCustomDateRangeAction, parameters);
 					return this._loadActivitiesForPeriod(periodUrl)
@@ -340,14 +336,6 @@
 						self._userName = null;
 					});
 				}
-			},
-
-			_goNext: function() {
-				return this._loadActivitiesForPeriod(this._nextPeriodUrl)
-					.catch(function() {
-						self._showError = true;
-						self._userName = null;
-					});
 			},
 
 			_getCustomRangeAction: function(activitiesUrl) {

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -14,6 +14,7 @@
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
 <link rel="import" href="d2l-all-assessments-list.html">
 <link rel="import" href="d2l-assessments-list.html">
+<link rel="import" href="d2l-date-dropdown.html">
 
 <dom-module id="d2l-upcoming-assessments">
 	<template>
@@ -47,41 +48,14 @@
 			}
 
 			.period-selection-container {
-				text-align: center;
-				margin-bottom: 10px;
-			}
-
-			.period-selection-container span {
-				padding-right: 7px;
-			}
-
-			.d2l-dropdown-opener {
 				display: flex;
-				align-items: center;
-			}
-
-			.d2l-dropdown-opener span {
-				color: var(--d2l-color-ferrite);
-			}
-
-			.d2l-dropdown-opener:hover,
-			.d2l-dropdown-opener:focus {
-				text-decoration: none;
+				justify-content: center;
+				margin-bottom: 10px;
 			}
 
 			:host-context([dir="rtl"]) h2 {
 				margin-left: 0px;
 				margin-right: 15px;
-			}
-
-			:host-context([dir="rtl"]) d2l-simple-overlay-close-button span {
-				padding-left: 0px;
-				padding-right: 7px;
-			}
-
-			:host-context([dir="rtl"]) .period-selection-container span {
-				padding-right: 0;
-				padding-left: 7px;
 			}
 
 			.error-message,
@@ -178,16 +152,7 @@
 				</div>
 			</div>
 			 <div class="period-selection-container">
-				 <d2l-dropdown>
-					 <a is="d2l-link" class="d2l-dropdown-opener">
-						 <span>[[_currentPeriodText]]</span>
-						 <d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
-					 </a>
-					 <d2l-dropdown-content align="start">
-						 <a is="d2l-link" href="javascript:void(0);" on-tap="_goPrev" on-keypress="_keypressGoPrev">[[localize('goPreviousText')]]</a>
-						 <a is="d2l-link" href="javascript:void(0);" on-tap="_goNext" on-keypress="_keypressGoNext">[[localize('goNextText')]]</a>
-					 </d2l-dropdown-content>
-				 </d2l-dropdown>
+				 <d2l-date-dropdown current-period-text=[[_currentPeriodText]]></d2l-date-dropdown>
 			</div>
 			<template is="dom-if" if="[[_hasActivities(_allActivities)]]">
 				<d2l-all-assessments-list assessment-items=[[_allActivities]]></d2l-all-assessments-list>

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -360,7 +360,7 @@
 				var day = selectedDate.getDay();
 				var startDate = new Date(selectedDate.setDate(selectedDate.getDate() - day));
 				var start = startDate.toISOString();
-				var twoWeeksFromStart = new Date(startDate.setDate(startDate.getDate() + 14));
+				var twoWeeksFromStart = new Date(startDate.setDate(startDate.getDate() + 13));
 				twoWeeksFromStart.setHours(23, 59, 59, 999);
 				var end = twoWeeksFromStart.toISOString();
 

--- a/test/components/d2l-date-dropdown.html
+++ b/test/components/d2l-date-dropdown.html
@@ -1,0 +1,21 @@
+<!doctype html>
+
+<html>
+	<head>
+		<title>d2l-date-dropdown test</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../../web-component-tester/browser.js"></script>
+
+		<link rel="import" href="../../components/d2l-date-dropdown.html">
+	</head>
+	<body>
+		<test-fixture id="basic">
+			<template>
+				<d2l-date-dropdown></d2l-date-dropdown>
+			</template>
+		</test-fixture>
+		<script src="d2l-date-dropdown.js"></script>
+	</body>
+</html>

--- a/test/components/d2l-date-dropdown.js
+++ b/test/components/d2l-date-dropdown.js
@@ -1,0 +1,58 @@
+/* global describe, it, fixture, expect, beforeEach */
+
+'use strict';
+
+describe('<d2l-date-dropdown>', function() {
+	var elem;
+
+	beforeEach(function() {
+		elem = fixture('basic');
+	});
+
+	describe('smoke test', function() {
+		it('should instantiate the element', function() {
+			expect(elem.is).to.equal('d2l-date-dropdown');
+		});
+	});
+	describe('value', function() {
+		describe('value tests', function() {
+			it('should default value to empty', function() {
+				expect(elem.value).to.be.empty;
+				expect(elem.hasAttribute('value')).to.be.true;
+			});
+			it('should set property when setting attribute', function() {
+				elem.setAttribute('value', '2017-07-01');
+				expect(elem.value).to.equal('2017-07-01');
+			});
+			it('should set attribute when setting value', function() {
+				elem.value = '2017-07-01';
+				expect(elem.getAttribute('value')).to.equal('2017-07-01');
+			});
+			it('should set vaadin picker when element value set', function() {
+				elem.value = '2017-06-01';
+				expect(elem.$$('vaadin-date-picker-light').value).to.equal('2017-06-01');
+			});
+			it('should set element value when vaadin picker value set', function() {
+				elem.$$('vaadin-date-picker-light').value = '2017-07-01';
+				expect(elem.value).to.equal('2017-07-01');
+			});
+		});
+		describe('value-change-event', function() {
+			it('should fire d2l-date-dropdown-value-changed event when element is changed', function(done) {
+				elem.addEventListener('d2l-date-dropdown-value-changed', function(e) {
+					expect(e.target).to.equal(elem);
+					done();
+				});
+				elem.value = '2017-07-01';
+			});
+			it('should send date when element is changed', function(done) {
+				var date = new Date(2017, 6, 1);
+				elem.addEventListener('d2l-date-dropdown-value-changed', function(e) {
+					expect(e.detail.date).to.deep.equal(date);
+					done();
+				});
+				elem.value = '2017-07-01';
+			});
+		});
+	});
+});

--- a/test/components/d2l-date-dropdown.js
+++ b/test/components/d2l-date-dropdown.js
@@ -60,25 +60,25 @@ describe('<d2l-date-dropdown>', function() {
 		it('should show the pointer when screen not small and iron-overlay-opened', function() {
 			elem._smallScreen = false;
 			elem._opened = true;
-			expect(elem.$$('.d2l-dropdown-content-pointer').style.display).to.equal('inline-block');
+			expect(elem.$$('.d2l-dropdown-content-pointer').style.opacity).to.equal('1');
 		});
 
 		it('should not show the pointer when screen not small and iron-overlay-closed', function() {
 			elem._smallScreen = false;
 			elem._opened = false;
-			expect(elem.$$('.d2l-dropdown-content-pointer').style.display).to.equal('none');
+			expect(elem.$$('.d2l-dropdown-content-pointer').style.opacity).to.equal('0');
 		});
 
 		it('should not show the pointer when screen small and iron-overlay-opened', function() {
 			elem._smallScreen = true;
 			elem._opened = true;
-			expect(elem.$$('.d2l-dropdown-content-pointer').style.display).to.equal('none');
+			expect(elem.$$('.d2l-dropdown-content-pointer').style.opacity).to.equal('0');
 		});
 
 		it('should not show the pointer when screen small and iron-overlay-closed', function() {
 			elem._smallScreen = false;
 			elem._opened = false;
-			expect(elem.$$('.d2l-dropdown-content-pointer').style.display).to.equal('none');
+			expect(elem.$$('.d2l-dropdown-content-pointer').style.opacity).to.equal('0');
 		});
 	});
 });

--- a/test/components/d2l-date-dropdown.js
+++ b/test/components/d2l-date-dropdown.js
@@ -55,4 +55,30 @@ describe('<d2l-date-dropdown>', function() {
 			});
 		});
 	});
+
+	describe('pointer visibility', function() {
+		it('should show the pointer when screen not small and iron-overlay-opened', function() {
+			elem._smallScreen = false;
+			elem._opened = true;
+			expect(elem.$$('.d2l-dropdown-content-pointer').style.display).to.equal('inline-block');
+		});
+
+		it('should not show the pointer when screen not small and iron-overlay-closed', function() {
+			elem._smallScreen = false;
+			elem._opened = false;
+			expect(elem.$$('.d2l-dropdown-content-pointer').style.display).to.equal('none');
+		});
+
+		it('should not show the pointer when screen small and iron-overlay-opened', function() {
+			elem._smallScreen = true;
+			elem._opened = true;
+			expect(elem.$$('.d2l-dropdown-content-pointer').style.display).to.equal('none');
+		});
+
+		it('should not show the pointer when screen small and iron-overlay-closed', function() {
+			elem._smallScreen = false;
+			elem._opened = false;
+			expect(elem.$$('.d2l-dropdown-content-pointer').style.display).to.equal('none');
+		});
+	});
 });

--- a/test/components/d2l-date-dropdown.js
+++ b/test/components/d2l-date-dropdown.js
@@ -55,30 +55,4 @@ describe('<d2l-date-dropdown>', function() {
 			});
 		});
 	});
-
-	describe('pointer visibility', function() {
-		it('should show the pointer when screen not small and iron-overlay-opened', function() {
-			elem._smallScreen = false;
-			elem._opened = true;
-			expect(elem.$$('.d2l-dropdown-content-pointer').style.opacity).to.equal('1');
-		});
-
-		it('should not show the pointer when screen not small and iron-overlay-closed', function() {
-			elem._smallScreen = false;
-			elem._opened = false;
-			expect(elem.$$('.d2l-dropdown-content-pointer').style.opacity).to.equal('0');
-		});
-
-		it('should not show the pointer when screen small and iron-overlay-opened', function() {
-			elem._smallScreen = true;
-			elem._opened = true;
-			expect(elem.$$('.d2l-dropdown-content-pointer').style.opacity).to.equal('0');
-		});
-
-		it('should not show the pointer when screen small and iron-overlay-closed', function() {
-			elem._smallScreen = false;
-			elem._opened = false;
-			expect(elem.$$('.d2l-dropdown-content-pointer').style.opacity).to.equal('0');
-		});
-	});
 });

--- a/test/components/d2l-upcoming-assessments.js
+++ b/test/components/d2l-upcoming-assessments.js
@@ -110,6 +110,8 @@ describe('<d2l-upcoming-assessments>', function() {
 					'end':'2017-09-03T03:59:59.999Z'
 				};
 				var range = element._getCustomDateRangeParameters(date);
+				expect(range.start).to.equal(expected.start);
+				expect(range.end).to.equal(expected.end);
 				expect(range).to.deep.equal(expected);
 			});
 		});

--- a/test/components/d2l-upcoming-assessments.js
+++ b/test/components/d2l-upcoming-assessments.js
@@ -84,35 +84,55 @@ describe('<d2l-upcoming-assessments>', function() {
 
 		describe('_getCustomDateRangeParameters', function() {
 			it('gets the correct range when selected date is a Tuesday', function() {
-				var date = new Date('Tue Sep 12 2017 00:00:00 GMT-0400 (EDT)');
+				var date = new Date('Tue Sep 12 2017 00:00:00');
 				var expected = {
-					start: '2017-09-10T04:00:00.000Z',
-					end: '2017-09-24T03:59:59.999Z'
+					start: 'Sept 10 2017 00:00:00',
+					end: 'Sept 23 2017 23:59:59'
 				};
 				var range = element._getCustomDateRangeParameters(date);
-				expect(range).to.deep.equal(expected);
+
+				var start = new Date(expected.start).toISOString();
+				var endDate = new Date(expected.end);
+				endDate.setMilliseconds(999);
+				var end = endDate.toISOString();
+
+				expect(range.start).to.equal(start);
+				expect(range.end).to.equal(end);
 			});
 
 			it('gets the correct range when selected date is a Sunday', function() {
-				var date = new Date('Sun Sep 03 2017 00:00:00 GMT-0400 (EDT)');
+				var date = new Date('Sun Sep 03 2017 00:00:00');
 				var expected = {
-					'start':'2017-09-03T04:00:00.000Z',
-					'end':'2017-09-17T03:59:59.999Z'
+					'start':'Sept 3 2017 00:00:00',
+					'end':'Sept 16 2017 23:59:59'
 				};
 				var range = element._getCustomDateRangeParameters(date);
-				expect(range).to.deep.equal(expected);
+
+				var start = new Date(expected.start).toISOString();
+				var endDate = new Date(expected.end);
+				endDate.setMilliseconds(999);
+				var end = endDate.toISOString();
+
+				expect(range.start).to.equal(start);
+				expect(range.end).to.equal(end);
 			});
 
 			it('gets the correct range when selected date is a Saturday', function() {
-				var date = new Date('Sat Aug 26 2017 00:00:00 GMT-0400 (EDT)');
+				var date = new Date('Sat Aug 26 2017 00:00:00');
 				var expected = {
-					'start':'2017-08-20T04:00:00.000Z',
-					'end':'2017-09-03T03:59:59.999Z'
+					'start':'Aug 20 2017 00:00:00',
+					'end':'Sept 2 2017 23:59:59'
 				};
+
 				var range = element._getCustomDateRangeParameters(date);
-				expect(range.start).to.equal(expected.start);
-				expect(range.end).to.equal(expected.end);
-				expect(range).to.deep.equal(expected);
+
+				var start = new Date(expected.start).toISOString();
+				var endDate = new Date(expected.end);
+				endDate.setMilliseconds(999);
+				var end = endDate.toISOString();
+
+				expect(range.start).to.equal(start);
+				expect(range.end).to.equal(end);
 			});
 		});
 
@@ -131,14 +151,24 @@ describe('<d2l-upcoming-assessments>', function() {
 						value:'2017-10-03T19:14:21.889Z'
 					}]
 				};
-				var date = new Date('Tue Sep 05 2017 00:00:00 GMT-0400 (EDT)');
+				var date = new Date('Tue Sep 05 2017 00:00:00');
 				var dateObj = {
 					detail: {
 						date: date
 					}
 				};
 
-				var expectedUrl = 'http://www.foo.com?start=2017-09-03T04:00:00.000Z&end=2017-09-17T03:59:59.999Z';
+				var expected = {
+					'start': 'Sept 3 2017 00:00:00',
+					'end': 'Sept 16 2017 23:59:59'
+				};
+
+				var start = new Date(expected.start).toISOString();
+				var endDate = new Date(expected.end);
+				endDate.setMilliseconds(999);
+				var end = endDate.toISOString();
+
+				var expectedUrl = 'http://www.foo.com?start=' + start + '&end=' + end;
 				return element._onDateValueChanged(dateObj)
 					.then(function() {
 						expect(element._loadActivitiesForPeriod).to.have.been.calledWith(expectedUrl);

--- a/test/components/d2l-upcoming-assessments.js
+++ b/test/components/d2l-upcoming-assessments.js
@@ -87,7 +87,7 @@ describe('<d2l-upcoming-assessments>', function() {
 				var date = new Date('Tue Sep 12 2017 00:00:00 GMT-0400 (EDT)');
 				var expected = {
 					start: '2017-09-10T04:00:00.000Z',
-					end: '2017-09-25T03:59:59.999Z'
+					end: '2017-09-24T03:59:59.999Z'
 				};
 				var range = element._getCustomDateRangeParameters(date);
 				expect(range).to.deep.equal(expected);
@@ -97,7 +97,7 @@ describe('<d2l-upcoming-assessments>', function() {
 				var date = new Date('Sun Sep 03 2017 00:00:00 GMT-0400 (EDT)');
 				var expected = {
 					'start':'2017-09-03T04:00:00.000Z',
-					'end':'2017-09-18T03:59:59.999Z'
+					'end':'2017-09-17T03:59:59.999Z'
 				};
 				var range = element._getCustomDateRangeParameters(date);
 				expect(range).to.deep.equal(expected);
@@ -107,7 +107,7 @@ describe('<d2l-upcoming-assessments>', function() {
 				var date = new Date('Sat Aug 26 2017 00:00:00 GMT-0400 (EDT)');
 				var expected = {
 					'start':'2017-08-20T04:00:00.000Z',
-					'end':'2017-09-04T03:59:59.999Z'
+					'end':'2017-09-03T03:59:59.999Z'
 				};
 				var range = element._getCustomDateRangeParameters(date);
 				expect(range).to.deep.equal(expected);
@@ -136,7 +136,7 @@ describe('<d2l-upcoming-assessments>', function() {
 					}
 				};
 
-				var expectedUrl = 'http://www.foo.com?start=2017-09-03T04:00:00.000Z&end=2017-09-18T03:59:59.999Z';
+				var expectedUrl = 'http://www.foo.com?start=2017-09-03T04:00:00.000Z&end=2017-09-17T03:59:59.999Z';
 				return element._onDateValueChanged(dateObj)
 					.then(function() {
 						expect(element._loadActivitiesForPeriod).to.have.been.calledWith(expectedUrl);

--- a/test/components/d2l-upcoming-assessments.js
+++ b/test/components/d2l-upcoming-assessments.js
@@ -250,7 +250,7 @@ describe('<d2l-upcoming-assessments>', function() {
 				element._getOverdueActivities = sandbox.stub().returns(activities);
 				element._getUserActivityUsagesInfos = sandbox.stub().returns(activities);
 				element._updateActivitiesInfo = sandbox.stub().returns(activities);
-				return element._loadActivitiesForPeriod(nextPeriodUrl)
+				return element._loadActivitiesForPeriod(periodUrl)
 					.then(function() {
 						expect(element._allActivities).to.equal(activities);
 					});
@@ -270,7 +270,7 @@ describe('<d2l-upcoming-assessments>', function() {
 				element._getOverdueActivities = sandbox.stub().returns(activities);
 				element._getUserActivityUsagesInfos = sandbox.stub().returns(activities);
 				element._updateActivitiesInfo = sandbox.stub().returns(activities);
-				return element._loadActivitiesForPeriod(nextPeriodUrl)
+				return element._loadActivitiesForPeriod(periodUrl)
 					.then(function() {
 						expect(element._assessments).to.not.equal(activities);
 					});

--- a/test/components/d2l-upcoming-assessments.js
+++ b/test/components/d2l-upcoming-assessments.js
@@ -5,8 +5,7 @@
 describe('<d2l-upcoming-assessments>', function() {
 
 	var element;
-	var nextPeriodUrl = '/some/period/beyond/now/';
-	var previousPeriodUrl = '/some/period/before/now/';
+	var periodUrl = '/some/period/now/';
 	var activities = {
 		properties: {
 			start: '2017-07-19T16:20:07.567Z',
@@ -83,24 +82,64 @@ describe('<d2l-upcoming-assessments>', function() {
 		// 	}, 20);
 		// });
 
-		describe('_goNext', function() {
-			it('invokes _loadActivitiesForPeriod with the nextPeriodUrl', function() {
-				element._loadActivitiesForPeriod = sandbox.stub().returns(Promise.resolve());
-				element._nextPeriodUrl = nextPeriodUrl;
-				return element._goNext()
-					.then(function() {
-						expect(element._loadActivitiesForPeriod).to.have.been.calledWith(nextPeriodUrl);
-					});
+		describe('_getCustomDateRangeParameters', function() {
+			it('gets the correct range when selected date is a Tuesday', function() {
+				var date = new Date('Tue Sep 12 2017 00:00:00 GMT-0400 (EDT)');
+				var expected = {
+					start: '2017-09-10T04:00:00.000Z',
+					end: '2017-09-25T03:59:59.999Z'
+				};
+				var range = element._getCustomDateRangeParameters(date);
+				expect(range).to.deep.equal(expected);
+			});
+
+			it('gets the correct range when selected date is a Sunday', function() {
+				var date = new Date('Sun Sep 03 2017 00:00:00 GMT-0400 (EDT)');
+				var expected = {
+					'start':'2017-09-03T04:00:00.000Z',
+					'end':'2017-09-18T03:59:59.999Z'
+				};
+				var range = element._getCustomDateRangeParameters(date);
+				expect(range).to.deep.equal(expected);
+			});
+
+			it('gets the correct range when selected date is a Saturday', function() {
+				var date = new Date('Sat Aug 26 2017 00:00:00 GMT-0400 (EDT)');
+				var expected = {
+					'start':'2017-08-20T04:00:00.000Z',
+					'end':'2017-09-04T03:59:59.999Z'
+				};
+				var range = element._getCustomDateRangeParameters(date);
+				expect(range).to.deep.equal(expected);
 			});
 		});
 
-		describe('_goPrev', function() {
-			it('invokes _loadActivitiesForPeriod with the previousPeriodUrl', function() {
+		describe('_onDateValueChanged', function() {
+			it('invokes _loadActivitiesForPeriod with the correct url', function() {
 				element._loadActivitiesForPeriod = sandbox.stub().returns(Promise.resolve());
-				element._previousPeriodUrl = previousPeriodUrl;
-				return element._goPrev()
+				element._selectCustomDateRangeAction = {
+					href: 'http://www.foo.com',
+					fields: [{
+						name:'start',
+						type:'text',
+						value:'2017-09-26T19:14:21.889Z'
+					}, {
+						name:'end',
+						type:'text',
+						value:'2017-10-03T19:14:21.889Z'
+					}]
+				};
+				var date = new Date('Tue Sep 05 2017 00:00:00 GMT-0400 (EDT)');
+				var dateObj = {
+					detail: {
+						date: date
+					}
+				};
+
+				var expectedUrl = 'http://www.foo.com?start=2017-09-03T04:00:00.000Z&end=2017-09-18T03:59:59.999Z';
+				return element._onDateValueChanged(dateObj)
 					.then(function() {
-						expect(element._loadActivitiesForPeriod).to.have.been.calledWith(previousPeriodUrl);
+						expect(element._loadActivitiesForPeriod).to.have.been.calledWith(expectedUrl);
 					});
 			});
 		});
@@ -122,9 +161,9 @@ describe('<d2l-upcoming-assessments>', function() {
 				element._fetchEntity = sandbox.stub().returns(Promise.resolve(
 					window.D2L.Hypermedia.Siren.Parse(activities)
 				));
-				return element._loadActivitiesForPeriod(nextPeriodUrl)
+				return element._loadActivitiesForPeriod(periodUrl)
 					.then(function() {
-						expect(element._fetchEntity).to.have.been.calledWith(nextPeriodUrl);
+						expect(element._fetchEntity).to.have.been.calledWith(periodUrl);
 					});
 			});
 
@@ -146,9 +185,9 @@ describe('<d2l-upcoming-assessments>', function() {
 				element._fetchEntity = sandbox.stub().returns(Promise.resolve(
 					window.D2L.Hypermedia.Siren.Parse(activities)
 				));
-				return element._getCustomRangeAction(nextPeriodUrl)
+				return element._getCustomRangeAction(periodUrl)
 					.then(function() {
-						expect(element._fetchEntity).to.have.been.calledWith(nextPeriodUrl);
+						expect(element._fetchEntity).to.have.been.calledWith(periodUrl);
 					});
 			});
 		});

--- a/test/index.html
+++ b/test/index.html
@@ -18,7 +18,8 @@
 				'./components/d2l-upcoming-assessments.html',
 				'./components/d2l-assessments-list.html',
 				'./components/d2l-assessments-list-item.html',
-				'./components/d2l-all-assessments-list-item.html'
+				'./components/d2l-all-assessments-list-item.html',
+				'./components/d2l-date-dropdown.html'
 			]);
 		</script>
 	</body>


### PR DESCRIPTION
https://rally1.rallydev.com/#/89963236876/detail/userstory/137138049580

This story was separated, so for this part
- Remove "previous" and "next"
- Add calendar "dropdown" (much of the date dropdown is from https://github.com/BrightspaceUI/date-picker/blob/master/d2l-date-picker.html though some customizations were made)
- When a date is selected in the dropdown, show the period of time from the previous Sunday (or midnight of that day if Sunday is selected) for the next 2 weeks, so until 11:59 PM of the Saturday ~2 weeks later

Note that the pointer above the calendar isn't working correct on RTL, though everything else should be working RTL. I'll fix that Monday.