### PR TITLE
Read instructions from richtext entities on assignment/quiz

### DIFF
--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -79,13 +79,13 @@
 		},
 
 		_getAssignmentInstructions: function(activity) {
-			var instructions = activity.getSubEntityByRel('https://assignments.api.brightspace.com/rels/instructions');
-			return instructions && instructions.hasClass('richtext') ? instructions.properties.text : '';
+			var instructions = activity.getSubEntityByRel(this.HypermediaRels.Assignments.instructions);
+			return instructions && instructions.hasClass(this.HypermediaClasses.text.richtext) ? instructions.properties.text : '';
 		},
 
 		_getQuizDescription: function(activity) {
-			var description = activity.getSubEntityByRel('https://quizzes.api.brightspace.com/rels/description');
-			return description && description.hasClass('richtext') ? description.properties.text : '';
+			var description = activity.getSubEntityByRel(this.HypermediaRels.Quizzes.description);
+			return description && description.hasClass(this.HypermediaClasses.text.richtext) ? description.properties.text : '';
 		},
 
 		/*

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -88,7 +88,7 @@
 
 		_getRichTextValuePreferPlainText: function(richtextEntity) {
 			if (!richtextEntity || !richtextEntity.hasClass(this.HypermediaClasses.text.richtext) ||
-		    	(!richtextEntity.properties.text && !richtextEntity.properties.html)) {
+			(!richtextEntity.properties.text && !richtextEntity.properties.html)) {
 				return '';
 			}
 

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -88,7 +88,7 @@
 
 		_getRichTextValuePreferPlainText: function(richtextEntity) {
 			if (!richtextEntity || !richtextEntity.hasClass(this.HypermediaClasses.text.richtext) ||
-			(!richtextEntity.properties.text && !richtextEntity.properties.html)) {
+				(!richtextEntity.properties.text && !richtextEntity.properties.html)) {
 				return '';
 			}
 

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -78,6 +78,16 @@
 			return this._fetchEntity(activityLink, getToken, userUrl);
 		},
 
+		_getAssignmentInstructions: function(activity) {
+			var instructions = activity.getSubEntityByRel('https://assignments.api.brightspace.com/rels/instructions');
+			return instructions && instructions.hasClass('richtext') ? instructions.properties.text : '';
+		},
+
+		_getQuizDescription: function(activity) {
+			var description = activity.getSubEntityByRel('https://quizzes.api.brightspace.com/rels/description');
+			return description && description.hasClass('richtext') ? description.properties.text : '';
+		},
+
 		/*
 		* Returns an object that contains the information required to populate an assessment list item
 		*/
@@ -109,11 +119,17 @@
 						var organization = response[1];
 
 						var type = self._getActivityType.call(self, activity);
+						var instructions;
+						if (type === 'quiz') {
+							instructions = self._getQuizDescription.call(self, activity);
+						} else if (type === 'assignment') {
+							instructions = self._getAssignmentInstructions.call(self, activity);
+						}
 
 						return {
 							name: activity.properties.name,
 							courseName: organization.properties.name,
-							instructions: activity.properties.instructionsText || activity.properties.instructions,
+							instructions: instructions,
 							dueDate: dueDateState.dueDate,
 							endDate: endDateState.endDate,
 							isCompleted: completionState.isCompleted,

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -79,13 +79,20 @@
 		},
 
 		_getAssignmentInstructions: function(activity) {
-			var instructions = activity.getSubEntityByRel(this.HypermediaRels.Assignments.instructions);
-			return instructions && instructions.hasClass(this.HypermediaClasses.text.richtext) ? instructions.properties.text : '';
+			return this._getRichTextValuePreferPlainText(activity.getSubEntityByRel(this.HypermediaRels.Assignments.instructions));
 		},
 
 		_getQuizDescription: function(activity) {
-			var description = activity.getSubEntityByRel(this.HypermediaRels.Quizzes.description);
-			return description && description.hasClass(this.HypermediaClasses.text.richtext) ? description.properties.text : '';
+			return this._getRichTextValuePreferPlainText(activity.getSubEntityByRel(this.HypermediaRels.Quizzes.description));
+		},
+
+		_getRichTextValuePreferPlainText: function(richtextEntity) {
+			if (!richtextEntity || !richtextEntity.hasClass(this.HypermediaClasses.text.richtext) ||
+		    	(!richtextEntity.properties.text && !richtextEntity.properties.html)) {
+				return '';
+			}
+
+			return richtextEntity.properties.text || richtextEntity.properties.html;
 		},
 
 		/*
@@ -119,17 +126,17 @@
 						var organization = response[1];
 
 						var type = self._getActivityType.call(self, activity);
-						var instructions;
+						var info;
 						if (type === 'quiz') {
-							instructions = self._getQuizDescription.call(self, activity);
+							info = self._getQuizDescription.call(self, activity);
 						} else if (type === 'assignment') {
-							instructions = self._getAssignmentInstructions.call(self, activity);
+							info = self._getAssignmentInstructions.call(self, activity);
 						}
 
 						return {
 							name: activity.properties.name,
 							courseName: organization.properties.name,
-							instructions: instructions,
+							info: info,
 							dueDate: dueDateState.dueDate,
 							endDate: endDateState.endDate,
 							isCompleted: completionState.isCompleted,

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
     "d2l-colors": "^2.2.3",
-    "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^2.4.0",
+    "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^2.6.0",
     "d2l-icons": "^3.1.2",
     "d2l-intl": "^0.4.1",
     "d2l-link": "^3.5.1",

--- a/components/d2l-all-assessments-list-item.html
+++ b/components/d2l-all-assessments-list-item.html
@@ -93,7 +93,7 @@
 				align-items: center;
 			}
 
-			.instructions {
+			.info {
 				@apply --d2l-body-compact-text;
 				font-size: 0.8rem;
 				font-weight: 300;
@@ -109,7 +109,7 @@
 				height: 18px;
 			}
 
-			:host-context([dir="rtl"]) .instructions {
+			:host-context([dir="rtl"]) .info {
 				padding-right: 0px;
 				padding-left: 30px;
 			}
@@ -121,7 +121,7 @@
 					border-right: 0px;
 				}
 
-				.instructions-row {
+				.info-row {
 					display: none;
 				}
 			}
@@ -161,9 +161,9 @@
 					</div>
 				</div>
 			</div>
-			<div class="row instructions-row">
+			<div class="row info-row">
 				<div class="spacer"></div>
-				<div class="instructions">[[assessmentItem.instructions]]</div>
+				<div class="info">[[assessmentItem.info]]</div>
 			</div>
 		</div>
 	</template>

--- a/test/behaviors/d2l-upcoming-assessments-behavior.js
+++ b/test/behaviors/d2l-upcoming-assessments-behavior.js
@@ -193,17 +193,60 @@ describe('d2l upcoming assessments behavior', function() {
 
 	describe('_getAssignmentInstructions', function() {
 		it('should return the text value from the richtext instructions entity', function() {
+			sandbox.spy(component, '_getRichTextValuePreferPlainText');
 			var assignment = getActivity('assignment');
 			var instructions = component._getAssignmentInstructions(assignment);
+
+			expect(component._getRichTextValuePreferPlainText).to.be.calledOnce;
 			expect(instructions).to.equal(activityInstructions);
 		});
+
 	});
 
 	describe('_getQuizDescription', function() {
 		it('should return the text value from the richtext description entity', function() {
+			sandbox.spy(component, '_getRichTextValuePreferPlainText');
 			var quiz = getActivity('quiz');
 			var description = component._getQuizDescription(quiz);
+
+			expect(component._getRichTextValuePreferPlainText).to.be.calledOnce;
 			expect(description).to.equal(quizDescription);
+		});
+	});
+
+	describe('_getRichTextValuePreferPlainText', function() {
+		it('should return empty string if no object is provided', function() {
+			var retval = component._getRichTextValuePreferPlainText();
+			expect(retval).to.equal('');
+		});
+
+		it('should return empty string if the entity provided does not have the richtext class', function() {
+			var retval = component._getRichTextValuePreferPlainText(getActivity('quiz'));
+			expect(retval).to.equal('');
+		});
+
+		it('should return empty string if both the html and text properties are empty', function() {
+			var richtext = getInstructions();
+			richtext.properties.text = null;
+			richtext.properties.html = null;
+
+			var retval = component._getRichTextValuePreferPlainText(parse(richtext));
+			expect(retval).to.equal('');
+		});
+
+		it('should prefer the text value from the richtext entity if both text and html are supplied', function() {
+			var richtext = getInstructions();
+
+			var retval = component._getRichTextValuePreferPlainText(parse(richtext));
+			expect(retval).to.equal(activityInstructions);
+		});
+
+		it('should return the html value from the richtext entity if the text value is empty', function() {
+			var richtext = getInstructions();
+			richtext.properties.text = null;
+
+			var retval = component._getRichTextValuePreferPlainText(parse(richtext));
+			expect(retval).to.equal('<p>' + activityInstructions + '</p>');
 		});
 	});
 
@@ -256,7 +299,7 @@ describe('d2l upcoming assessments behavior', function() {
 				});
 		});
 
-		it('should set the instructions to the value returned from _getAssignmentInstructions if the activity is an assignment', function() {
+		it('should set the info property to the value returned from _getAssignmentInstructions if the activity is an assignment', function() {
 			component._getAssignmentInstructions = sandbox.stub().returns('bonita bonita bonita');
 			component._getQuizDescription = sandbox.stub().returns('time for new flava in ya ear');
 
@@ -264,11 +307,11 @@ describe('d2l upcoming assessments behavior', function() {
 			.then(function(response) {
 				expect(component._getAssignmentInstructions).to.be.called;
 				expect(component._getQuizDescription).not.to.be.called;
-				expect(response[0].instructions).to.equal('bonita bonita bonita');
+				expect(response[0].info).to.equal('bonita bonita bonita');
 			});
 		});
 
-		it('should set the instructions to the value returned from _getQuizDescription if the activity is a quiz', function() {
+		it('should set the info property to the value returned from _getQuizDescription if the activity is a quiz', function() {
 			component._getActivityRequest = sandbox.stub().returns(Promise.resolve(getActivity('quiz')));
 			component._getAssignmentInstructions = sandbox.stub().returns('bonita bonita bonita');
 			component._getQuizDescription = sandbox.stub().returns('time for new flava in ya ear');
@@ -277,7 +320,7 @@ describe('d2l upcoming assessments behavior', function() {
 			.then(function(response) {
 				expect(component._getAssignmentInstructions).not.to.be.called;
 				expect(component._getQuizDescription).to.be.called;
-				expect(response[0].instructions).to.equal('time for new flava in ya ear');
+				expect(response[0].info).to.equal('time for new flava in ya ear');
 			});
 		});
 
@@ -302,7 +345,7 @@ describe('d2l upcoming assessments behavior', function() {
 				.then(function(response) {
 					expect(response[0].name).to.equal(activityName);
 					expect(response[0].courseName).to.equal(organizationName);
-					expect(response[0].instructions).to.equal(activityInstructions);
+					expect(response[0].info).to.equal(activityInstructions);
 					expect(response[0].dueDate).to.equal(dueDate);
 					expect(response[0].endDate).to.equal(endDate);
 					expect(response[0].isCompleted).to.equal(true);

--- a/test/components/d2l-all-assessments-list-item.js
+++ b/test/components/d2l-all-assessments-list-item.js
@@ -29,7 +29,7 @@ describe('<d2l-all-assessments-list-item>', function() {
 		var item = {
 			name: 'Name',
 			courseName: 'Course',
-			instructionsText: 'Instructions',
+			info: 'Instructions',
 			dueDate: nowish(dueDateModifier),
 			endDate: nowish(endDateModifier),
 			isCompleted: isCompleted,


### PR DESCRIPTION
[US90636 - Description for quizzes](https://rally1.rallydev.com/#/89963236876d/detail/userstory/156522784044)

Requires: 
https://git.dev.d2l/projects/CORE/repos/le/pull-requests/8375/overview
https://git.dev.d2l/projects/CORE/repos/le/pull-requests/8366/overview

Ultimately adds functionality to display quiz description when provided by the API. Due to API changes to the assignment instructions performed in le/8375 there is also modification to the handling of those as well.