### PR TITLE
US89797 - Allow course name to scale and wrap to next line

### DIFF
--- a/components/d2l-assessments-list-item.html
+++ b/components/d2l-assessments-list-item.html
@@ -82,11 +82,7 @@
 				overflow-wrap: break-word;
 			}
 
-			.assessment-type {
-				display: inline;
-			}
-
-			.date {
+			.date, .assessment-type {
 				display: inline;
 			}
 		</style>

--- a/components/d2l-assessments-list-item.html
+++ b/components/d2l-assessments-list-item.html
@@ -37,6 +37,7 @@
 
 			.info-container {
 				display: block;
+				width: calc(100% - 44px);
 			}
 
 			iron-icon.completion-icon {
@@ -72,6 +73,7 @@
 				display: inline-flex;
 				flex: 1;
 				align-items: center;
+				max-width: 100%;
 			}
 
 			.course-name {

--- a/components/d2l-assessments-list-item.html
+++ b/components/d2l-assessments-list-item.html
@@ -79,6 +79,7 @@
 			.course-name {
 				display: inline;
 				word-wrap: break-word;
+				overflow-wrap: break-word;
 			}
 
 			.assessment-type {

--- a/components/d2l-assessments-list-item.html
+++ b/components/d2l-assessments-list-item.html
@@ -31,10 +31,11 @@
 			.assessment-info {
 				@apply --d2l-body-standard-text;
 				font-size: 12px;
-				display: flex;
-				flex-direction: row;
-				align-items: center;
+				/* display: flex; */
+				/* flex-direction: row; */
+				/* align-items: center; */
 				line-height: 1;
+				display: block;
 			}
 
 			.info-container {
@@ -76,6 +77,18 @@
 				align-items: center;
 			}
 
+			.course-name {
+				display: inline;
+				word-wrap: break-word;
+			}
+
+			.assessment-type {
+				display: inline;
+			}
+
+			.date {
+				display: inline;
+			}
 		</style>
 			<div class="activity-info">
 				<div class="activity-icon-container">
@@ -84,7 +97,7 @@
 				<div class="info-container">
 					<h3 class="assessment-title">{{assessmentItem.name}}</h3>
 					<div class="assessment-info">
-						<div class="course-name">{{assessmentItem.courseName}}</div>
+						<div class="course-name">Grade 4 math with an extremely long name that causes everything to break and it's so looooooooooooonnnnnnnnnnnnnngggggggg {{assessmentItem.courseName}}</div>
 						<iron-icon class="separator-icon" icon="d2l-tier1:bullet"></iron-icon>
 						<div class="assessment-type">[[_getAssessmentType(assessmentItem)]]</div>
 						<template is="dom-if" if="[[_hasDueDate(assessmentItem)]]">

--- a/components/d2l-assessments-list-item.html
+++ b/components/d2l-assessments-list-item.html
@@ -31,9 +31,6 @@
 			.assessment-info {
 				@apply --d2l-body-standard-text;
 				font-size: 12px;
-				/* display: flex; */
-				/* flex-direction: row; */
-				/* align-items: center; */
 				line-height: 1;
 				display: block;
 			}

--- a/components/d2l-assessments-list-item.html
+++ b/components/d2l-assessments-list-item.html
@@ -97,7 +97,7 @@
 				<div class="info-container">
 					<h3 class="assessment-title">{{assessmentItem.name}}</h3>
 					<div class="assessment-info">
-						<div class="course-name">Grade 4 math with an extremely long name that causes everything to break and it's so looooooooooooonnnnnnnnnnnnnngggggggg {{assessmentItem.courseName}}</div>
+						<div class="course-name">{{assessmentItem.courseName}}</div>
 						<iron-icon class="separator-icon" icon="d2l-tier1:bullet"></iron-icon>
 						<div class="assessment-type">[[_getAssessmentType(assessmentItem)]]</div>
 						<template is="dom-if" if="[[_hasDueDate(assessmentItem)]]">

--- a/components/d2l-assessments-list.html
+++ b/components/d2l-assessments-list.html
@@ -21,7 +21,6 @@
 		</style>
 		<template is="dom-repeat" items="[[assessmentItems]]">
 			<d2l-assessments-list-item assessment-item="[[item]]"></d2l-assessments-list-item>
-			<d2l-assessments-list-item assessment-item="[[item]]"></d2l-assessments-list-item>
 		</template>
 	</template>
 	<script>

--- a/components/d2l-assessments-list.html
+++ b/components/d2l-assessments-list.html
@@ -14,7 +14,7 @@
 			}
 
 			@media (max-width: 767px) {
-				d2l-assessments-list-item:nth-of-type(4) {
+				d2l-assessments-list-item:nth-of-type(n+4) {
 					display: none;
 				}
 			}

--- a/components/d2l-assessments-list.html
+++ b/components/d2l-assessments-list.html
@@ -21,6 +21,7 @@
 		</style>
 		<template is="dom-repeat" items="[[assessmentItems]]">
 			<d2l-assessments-list-item assessment-item="[[item]]"></d2l-assessments-list-item>
+			<d2l-assessments-list-item assessment-item="[[item]]"></d2l-assessments-list-item>
 		</template>
 	</template>
 	<script>

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -18,6 +18,10 @@
 	<template>
 		<style>
 			:host {
+				/* display: flex;
+				flex-direction: column;
+				flex-grow: 1;
+				min-width: 0; */
 				display: block;
 			}
 
@@ -68,11 +72,6 @@
 				margin-bottom: 0;
 			}
 
-			.view-all-assignments-link {
-				bottom: 0;
-				display: inline-block;
-			}
-
 			.no-assessments-in-time-frame {
 				text-align: center;
 			}
@@ -108,6 +107,12 @@
 				color: var(--d2l-color-celestuba);
 			}
 
+			@media (min-width: 992px) {
+				.view-all-assignments-link {
+					position: absolute;
+					bottom: 0;
+				}
+			}
 		</style>
 
 

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -18,10 +18,6 @@
 	<template>
 		<style>
 			:host {
-				/* display: flex;
-				flex-direction: column;
-				flex-grow: 1;
-				min-width: 0; */
 				display: block;
 			}
 

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -67,8 +67,8 @@
 			}
 
 			.view-all-assignments-link {
-				position: absolute;
 				bottom: 0;
+				display: inline-block;
 			}
 
 			.no-assessments-in-time-frame {


### PR DESCRIPTION
[Related parent-portal-ui PR](https://github.com/Brightspace/parent-portal-ui/pull/376)

The upcoming assessments widget now looks something like this for a long course name:
![capture](https://user-images.githubusercontent.com/31708409/31736624-e8961d84-b40a-11e7-93ab-f0484b0f0526.JPG)

This change also required changes to parent-portal-ui in order for the widget heights to scale properly to the longest widget.