### PR TITLE
Bump to new major of d2l-fetch-siren-entity-behavior

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
     "d2l-colors": "^2.2.3",
     "d2l-date-picker": "~0.0.12",
-    "d2l-fetch-siren-entity-behavior": "Brightspace/d2l-fetch-siren-entity-behavior#^2.0.0",
+    "d2l-fetch-siren-entity-behavior": "Brightspace/d2l-fetch-siren-entity-behavior#^3.0.0",
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^2.6.0",
     "d2l-icons": "^3.1.2",
     "d2l-intl": "^0.4.1",


### PR DESCRIPTION
We don't make use of any of the changed features in this repo but it keeps it to the same version as used by recent grades and the parent portal.