### PR TITLE
backport: Fail gracefully for failed activity requests

### DIFF
--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -75,7 +75,14 @@
 		_getActivityRequest: function(userActivityUsage, getToken, userUrl) {
 			var activityLink = (userActivityUsage.getLinkByRel(this.HypermediaRels.assignment)
 					|| userActivityUsage.getLinkByRel(this.HypermediaRels.quiz) || {}).href;
-			return this._fetchEntity(activityLink, getToken, userUrl);
+			return Promise.resolve(this._fetchEntity(activityLink, getToken, userUrl))
+				.catch(function(err) {
+					var status = typeof err === 'number' ? err : err && err.status;
+					if (typeof status === 'number' && status >= 400 && status < 500) {
+						return null;
+					}
+					throw err;
+				});
 		},
 
 		_getAssignmentInstructions: function(activity) {
@@ -125,6 +132,10 @@
 						var activity = response[0];
 						var organization = response[1];
 
+						if (!activity) {
+							return null;
+						}
+
 						var type = self._getActivityType.call(self, activity);
 						var info;
 						if (type === 'quiz') {
@@ -150,7 +161,16 @@
 				requests.push(request);
 			});
 
-			return Promise.all(requests);
+			return Promise.all(requests)
+				.then(function(responses) {
+					var successResponses = responses.filter(function(response) {
+						return !!response;
+					});
+					if (responses.length && !successResponses.length) {
+						return Promise.reject(new Error('All activity requests failed'));
+					}
+					return successResponses;
+				});
 		},
 
 		_getUserActivityUsages: function(userEntity, getToken, userUrl) {

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -280,11 +280,11 @@
 
 								var basicListActivities = upcomingActivities.slice(0, 4);
 								self.set('_assessments', basicListActivities);
-							})
-							.catch(function() {
-								self._showError = true;
-								self._userName = null;
 							});
+					})
+					.catch(function() {
+						self._showError = true;
+						self._userName = null;
 					});
 			},
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -52,6 +52,12 @@
 					token="foozleberries">
 				</d2l-upcoming-assessments>
 			</div>
+
+			<script>
+				document.querySelectorAll('d2l-upcoming-assessments').forEach(function(assessment) {
+					assessment.getToken = function() { return Promise.resolve('foozleberries'); };
+				});
+			</script>
 		</d2l-demo-template>
 	</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-upcoming-assessments",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "description": "A widget to display upcoming assessments for a given user",
   "main": "index.js",
   "directories": {
@@ -13,7 +13,7 @@
     "test:lint:js": "eslint --ext .js,.html . behaviors/ components/ demo/ lang/ test/",
     "test:lint:wc": "polymer lint",
     "test:wct": "polymer test -p",
-    "test:wct:local": "cross-env LAUNCHPAD_BROWSERS=firefox polymer test -p --skip-plugin sauce"
+    "test:wct:local": "cross-env LAUNCHPAD_BROWSERS=chrome polymer test -p --skip-plugin sauce"
   },
   "repository": {
     "type": "git",

--- a/test/behaviors/d2l-upcoming-assessments-behavior.js
+++ b/test/behaviors/d2l-upcoming-assessments-behavior.js
@@ -270,6 +270,39 @@ describe('d2l upcoming assessments behavior', function() {
 
 			expect(component._fetchEntity).to.have.been.called;
 		});
+
+		it('should resolve null when the request fails with 4xx', function() {
+			var usage = getUserActivityUsage('assignment');
+			component._fetchEntity = sandbox.stub().returns(Promise.reject(404));
+
+			return component._getActivityRequest(usage, getToken, userUrl)
+				.then(function(result) {
+					expect(result).to.be.null;
+				});
+		});
+
+		it('should resolve null when the request fails with 4xx', function() {
+			var usage = getUserActivityUsage('assignment');
+			component._fetchEntity = sandbox.stub().returns(Promise.reject({ status: 400 }));
+
+			return component._getActivityRequest(usage, getToken, userUrl)
+				.then(function(result) {
+					expect(result).to.be.null;
+				});
+		});
+
+		it('should reject when the request fails with server error', function() {
+			var usage = getUserActivityUsage('assignment');
+			component._fetchEntity = sandbox.stub().returns(Promise.reject(500));
+
+			return component._getActivityRequest(usage, getToken, userUrl)
+				.then(function() {
+					return Promise.reject();
+				})
+				.catch(function(err) {
+					expect(err).to.equal(500);
+				});
+		});
 	});
 
 	describe('_getUserActivityUsagesInfos', function() {
@@ -321,6 +354,33 @@ describe('d2l upcoming assessments behavior', function() {
 				expect(component._getAssignmentInstructions).not.to.be.called;
 				expect(component._getQuizDescription).to.be.called;
 				expect(response[0].info).to.equal('time for new flava in ya ear');
+			});
+		});
+
+		it('should fail when all the activity requests fail', function() {
+			component._getActivityRequest = sandbox.stub().returns(Promise.resolve(null));
+
+			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
+			.then(function() {
+				return Promise.reject('Expect failure');
+			})
+			.catch(function() {
+				return;
+			});
+		});
+
+		it('should not fail when some of the activity requests fail', function() {
+			component._getActivityRequest.onSecondCall().returns(Promise.resolve(null));
+			component._getAssignmentInstructions = sandbox.stub().returns('bonita bonita bonita');
+			component._getQuizDescription = sandbox.stub().returns('time for new flava in ya ear');
+
+			userUsages = parse({ entities: [userUsage, userUsage] });
+
+			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
+			.then(function(response) {
+				expect(component._getAssignmentInstructions).to.be.called;
+				expect(component._getQuizDescription).not.to.be.called;
+				expect(response[0].info).to.equal('bonita bonita bonita');
 			});
 		});
 

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -2,7 +2,7 @@
   "plugins": {
     "local": {
       "browsers": [{
-        "browserName": "firefox"
+        "browserName": "chrome"
       }]
     },
     "sauce": {


### PR DESCRIPTION
Fixes [DE28074 - 10.7.7 Upcoming Assignments are not loaded when one of the folders is not found](https://rally1.rallydev.com/#/157196228032d/detail/defect/169949292432)

NOTE: Branch name is incorrect, I crossed the streams. Sorry for confusion, but this is specifically for 10.7.7.

Couldn't cherry-pick the original because the `d2l-fetch-siren-entity-behavior` didn't exist pre-10.7.8. Will need a set of eyes/testing. Should be able to cherry-pick this one back to 10.7.6.