### PR TITLE
US91864 - Limiting title to one line with '...'

### DIFF
--- a/components/d2l-assessments-list-item.html
+++ b/components/d2l-assessments-list-item.html
@@ -26,6 +26,9 @@
 				font-size: 16px;
 				line-height: 1.2rem;
 				font-weight: normal;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
 			}
 
 			.assessment-info {
@@ -42,6 +45,11 @@
 
 			iron-icon.completion-icon {
 				fill: var(--d2l-color-olivine);
+				margin-left: 10px;
+			}
+			:host-context([dir="rtl"]) iron-icon.completion-icon {
+				margin-left: 0;
+				margin-right: 10px;
 			}
 
 			iron-icon.separator-icon {
@@ -73,7 +81,7 @@
 				display: inline-flex;
 				flex: 1;
 				align-items: center;
-				max-width: 100%;
+				min-width: 0;
 			}
 
 			.course-name {


### PR DESCRIPTION
In action:
![image](https://user-images.githubusercontent.com/5125171/32390579-51418e9e-c0a5-11e7-994f-f60f581e8e68.png)

The extra 10px margin around the checkmark icon seemed necessary and consistent with what we've done in recent grades.