### PR TITLE
Use custom 2 week window for activities usages

### DIFF
--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -174,9 +174,13 @@
 
 		_getUserActivityUsages: function(userEntity, getToken, userUrl) {
 			var myActivitiesLink = (userEntity.getLinkByRel(this.HypermediaRels.Activities.myActivities) || {}).href;
+			var self = this;
 
 			if (myActivitiesLink) {
-				return this._fetchEntityWithToken(myActivitiesLink, getToken, userUrl);
+				return this._getCustomRangeAction(myActivitiesLink)
+					.then(function(actitiviesLink) {
+						return self._fetchEntityWithToken(actitiviesLink, getToken, userUrl);
+					});
 			}
 		},
 
@@ -189,6 +193,57 @@
 
 			// API doesn't include the overdue link if user doesn't have any overdue activities
 			return window.D2L.Hypermedia.Siren.Parse({});
+		},
+
+		_getCustomRangeAction: function(activitiesUrl) {
+			if (!activitiesUrl) {
+				return Promise.reject();
+			}
+
+			var self = this;
+
+			return this._fetchEntityWithToken(activitiesUrl, this.getToken, this.userUrl)
+				.then(function(activities) {
+					var currentTime = new Date();
+					var parameters = self._getCustomDateRangeParameters(currentTime);
+					var action = (activities.getActionByName(self.HypermediaActions.activities.selectCustomDateRange) || {});
+
+					self._selectCustomDateRangeAction = action;
+					return self._createActionUrl(action, parameters);
+				});
+		},
+
+		_getCustomDateRangeParameters: function(selectedDate) {
+			var day = selectedDate.getDay();
+			var startDate = new Date(selectedDate.setDate(selectedDate.getDate() - day));
+			var start = startDate.toISOString();
+			var twoWeeksFromStart = new Date(startDate.setDate(startDate.getDate() + 13));
+			twoWeeksFromStart.setHours(23, 59, 59, 999);
+			var end = twoWeeksFromStart.toISOString();
+
+			return {
+				start: start,
+				end: end
+			};
+		},
+
+		_createActionUrl: function(action, parameters) {
+			var query = {};
+			if (action.fields) {
+				action.fields.forEach(function(field) {
+					if (parameters.hasOwnProperty(field.name)) {
+						query[field.name] = parameters[field.name];
+					} else {
+						query[field.name] = field.value;
+					}
+				});
+			}
+
+			var queryString = Object.keys(query).map(function(key) {
+				return key + '=' + query[key];
+			}).join('&');
+
+			return queryString ? action.href + '?' + queryString : action.href;
 		}
 	};
 

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -342,59 +342,6 @@
 				}
 			},
 
-			_getCustomRangeAction: function(activitiesUrl) {
-				if (!activitiesUrl) {
-					return Promise.reject();
-				}
-
-				var self = this;
-
-				return this._fetchEntityWithToken(activitiesUrl, this.getToken, this.userUrl)
-					.then(function(activities) {
-						var currentTime = new Date();
-						currentTime.setHours(0, 0, 0, 0);
-						var parameters = self._getCustomDateRangeParameters(currentTime);
-
-						var action = (activities.getActionByName(self.HypermediaActions.activities.selectCustomDateRange) || {});
-						self._selectCustomDateRangeAction = action;
-
-						return self._createActionUrl(action, parameters);
-					});
-			},
-
-			_getCustomDateRangeParameters: function(selectedDate) {
-				var day = selectedDate.getDay();
-				var startDate = new Date(selectedDate.setDate(selectedDate.getDate() - day));
-				var start = startDate.toISOString();
-				var twoWeeksFromStart = new Date(startDate.setDate(startDate.getDate() + 13));
-				twoWeeksFromStart.setHours(23, 59, 59, 999);
-				var end = twoWeeksFromStart.toISOString();
-
-				return {
-					start: start,
-					end: end
-				};
-			},
-
-			_createActionUrl: function(action, parameters) {
-				var query = {};
-				if (action.fields) {
-					action.fields.forEach(function(field) {
-						if (parameters.hasOwnProperty(field.name)) {
-							query[field.name] = parameters[field.name];
-						} else {
-							query[field.name] = field.value;
-						}
-					});
-				}
-
-				var queryString = Object.keys(query).map(function(key) {
-					return key + '=' + query[key];
-				}).join('&');
-
-				return queryString ? action.href + '?' + queryString : action.href;
-			},
-
 			_loadActivitiesForPeriod: function(periodUrl) {
 				if (!periodUrl) {
 					return Promise.reject();

--- a/test/behaviors/d2l-upcoming-assessments-behavior.js
+++ b/test/behaviors/d2l-upcoming-assessments-behavior.js
@@ -416,4 +416,89 @@ describe('d2l upcoming assessments behavior', function() {
 				});
 		});
 	});
+
+	describe('_getCustomDateRangeParameters', function() {
+		it('gets the correct range when selected date is a Tuesday', function() {
+			var date = new Date('Tue Sep 12 2017 00:00:00');
+			var expected = {
+				start: 'Sept 10 2017 00:00:00',
+				end: 'Sept 23 2017 23:59:59'
+			};
+			var range = component._getCustomDateRangeParameters(date);
+
+			var start = new Date(expected.start).toISOString();
+			var endDate = new Date(expected.end);
+			endDate.setMilliseconds(999);
+			var end = endDate.toISOString();
+
+			expect(range.start).to.equal(start);
+			expect(range.end).to.equal(end);
+		});
+
+		it('gets the correct range when selected date is a Sunday', function() {
+			var date = new Date('Sun Sep 03 2017 00:00:00');
+			var expected = {
+				'start':'Sept 3 2017 00:00:00',
+				'end':'Sept 16 2017 23:59:59'
+			};
+			var range = component._getCustomDateRangeParameters(date);
+
+			var start = new Date(expected.start).toISOString();
+			var endDate = new Date(expected.end);
+			endDate.setMilliseconds(999);
+			var end = endDate.toISOString();
+
+			expect(range.start).to.equal(start);
+			expect(range.end).to.equal(end);
+		});
+
+		it('gets the correct range when selected date is a Saturday', function() {
+			var date = new Date('Sat Aug 26 2017 00:00:00');
+			var expected = {
+				'start':'Aug 20 2017 00:00:00',
+				'end':'Sept 2 2017 23:59:59'
+			};
+
+			var range = component._getCustomDateRangeParameters(date);
+
+			var start = new Date(expected.start).toISOString();
+			var endDate = new Date(expected.end);
+			endDate.setMilliseconds(999);
+			var end = endDate.toISOString();
+
+			expect(range.start).to.equal(start);
+			expect(range.end).to.equal(end);
+		});
+	});
+
+	describe('_getCustomRangeAction', function() {
+		var periodUrl = '/some/period/now/';
+		var activities = {
+			properties: {
+				start: '2017-07-19T16:20:07.567Z',
+				end: '2017-08-02T16:20:07.567Z'
+			}
+		};
+
+		it('does nothing if the provided url was not set', function() {
+			component._fetchEntityWithToken = sandbox.stub();
+			return component._getCustomRangeAction()
+				.then(function() {
+					return Promise.reject('Expected _getCustomRangeAction to reject');
+				})
+				.catch(function() {
+					expect(component._fetchEntityWithToken).to.not.have.been.called;
+				});
+		});
+
+		it('calls _fetchEntityWithToken for the provided url', function() {
+			component._fetchEntityWithToken = sandbox.stub().returns(Promise.resolve(
+				window.D2L.Hypermedia.Siren.Parse(activities)
+			));
+			return component._getCustomRangeAction(periodUrl)
+				.then(function() {
+					expect(component._fetchEntityWithToken).to.have.been.calledWith(periodUrl);
+				});
+		});
+	});
 });

--- a/test/components/d2l-upcoming-assessments.js
+++ b/test/components/d2l-upcoming-assessments.js
@@ -119,60 +119,6 @@ describe('<d2l-upcoming-assessments>', function() {
 			});
 		});
 
-		describe('_getCustomDateRangeParameters', function() {
-			it('gets the correct range when selected date is a Tuesday', function() {
-				var date = new Date('Tue Sep 12 2017 00:00:00');
-				var expected = {
-					start: 'Sept 10 2017 00:00:00',
-					end: 'Sept 23 2017 23:59:59'
-				};
-				var range = element._getCustomDateRangeParameters(date);
-
-				var start = new Date(expected.start).toISOString();
-				var endDate = new Date(expected.end);
-				endDate.setMilliseconds(999);
-				var end = endDate.toISOString();
-
-				expect(range.start).to.equal(start);
-				expect(range.end).to.equal(end);
-			});
-
-			it('gets the correct range when selected date is a Sunday', function() {
-				var date = new Date('Sun Sep 03 2017 00:00:00');
-				var expected = {
-					'start':'Sept 3 2017 00:00:00',
-					'end':'Sept 16 2017 23:59:59'
-				};
-				var range = element._getCustomDateRangeParameters(date);
-
-				var start = new Date(expected.start).toISOString();
-				var endDate = new Date(expected.end);
-				endDate.setMilliseconds(999);
-				var end = endDate.toISOString();
-
-				expect(range.start).to.equal(start);
-				expect(range.end).to.equal(end);
-			});
-
-			it('gets the correct range when selected date is a Saturday', function() {
-				var date = new Date('Sat Aug 26 2017 00:00:00');
-				var expected = {
-					'start':'Aug 20 2017 00:00:00',
-					'end':'Sept 2 2017 23:59:59'
-				};
-
-				var range = element._getCustomDateRangeParameters(date);
-
-				var start = new Date(expected.start).toISOString();
-				var endDate = new Date(expected.end);
-				endDate.setMilliseconds(999);
-				var end = endDate.toISOString();
-
-				expect(range.start).to.equal(start);
-				expect(range.end).to.equal(end);
-			});
-		});
-
 		describe('_onDateValueChanged', function() {
 			it('invokes _loadActivitiesForPeriod with the correct url', function() {
 				element._loadActivitiesForPeriod = sandbox.stub().returns(Promise.resolve());
@@ -331,29 +277,6 @@ describe('<d2l-upcoming-assessments>', function() {
 				.then(function() {
 					expect(element._assessments.toString()).to.equal([1, 2, 3, 4].toString());
 				});
-			});
-		});
-
-		describe('_getCustomRangeAction', function() {
-			it('does nothing if the provided url was not set', function() {
-				element._fetchEntityWithToken = sandbox.stub();
-				return element._getCustomRangeAction()
-					.then(function() {
-						return Promise.reject('Expected _getCustomRangeAction to reject');
-					})
-					.catch(function() {
-						expect(element._fetchEntityWithToken).to.not.have.been.called;
-					});
-			});
-
-			it('calls _fetchEntityWithToken for the provided url', function() {
-				element._fetchEntityWithToken = sandbox.stub().returns(Promise.resolve(
-					window.D2L.Hypermedia.Siren.Parse(activities)
-				));
-				return element._getCustomRangeAction(periodUrl)
-					.then(function() {
-						expect(element._fetchEntityWithToken).to.have.been.calledWith(periodUrl);
-					});
 			});
 		});
 


### PR DESCRIPTION
Basically on the student selection screen, for the upcoming assessments count, we were pulling activities for the default date range provided by the user api call - so one week I believe.  This uses the custom date range used by the assessment widget - moved over to the already shared behavior.

This could definitely use some solid review and hopefully pre-merge testing. 