### PR TITLE
use latest hm consts

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "d2l-colors": "^2.2.3",
     "d2l-date-picker": "~0.0.12",
     "d2l-fetch-siren-entity-behavior": "Brightspace/d2l-fetch-siren-entity-behavior#^3.0.0",
-    "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^2.6.0",
+    "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^3.0.0",
     "d2l-icons": "^3.1.2",
     "d2l-intl": "^0.4.1",
     "d2l-link": "^3.5.1",


### PR DESCRIPTION
The breaking changes from the major version (grades, notifications) shouldn't have impact on this repo.