### PR TITLE
US92068/DE28161 - Lengthy course text for upcoming work widget

### DIFF
--- a/components/d2l-assessments-list-item.html
+++ b/components/d2l-assessments-list-item.html
@@ -37,8 +37,6 @@
 				line-height: 1;
 				display: flex;
 				flex-direction: column;
-				/* align-items: center; */
-				/* display: block; */
 			}
 
 			.info-container {
@@ -85,13 +83,9 @@
 				flex: 1;
 				align-items: center;
 				min-width: 0;
-				/* max-width: 100%; */
 			}
 
 			.course-name {
-				/* display: inline;
-				word-wrap: break-word;
-				overflow-wrap: break-word; */
 				overflow: hidden;
 				text-overflow: ellipsis;
 				white-space: nowrap;
@@ -114,7 +108,6 @@
 					<div class="assessment-info">
 						<div class="course-name">{{assessmentItem.courseName}}</div>
 						<div class="assessment-details">
-							<!-- <iron-icon class="separator-icon" icon="d2l-tier1:bullet"></iron-icon> -->
 							<div class="assessment-type">[[_getAssessmentType(assessmentItem)]]</div>
 							<template is="dom-if" if="[[_hasDueDate(assessmentItem)]]">
 								<iron-icon class="separator-icon" icon="d2l-tier1:bullet"></iron-icon>

--- a/components/d2l-assessments-list-item.html
+++ b/components/d2l-assessments-list-item.html
@@ -35,7 +35,10 @@
 				@apply --d2l-body-standard-text;
 				font-size: 12px;
 				line-height: 1;
-				display: block;
+				display: flex;
+				flex-direction: column;
+				/* align-items: center; */
+				/* display: block; */
 			}
 
 			.info-container {
@@ -82,16 +85,24 @@
 				flex: 1;
 				align-items: center;
 				min-width: 0;
+				/* max-width: 100%; */
 			}
 
 			.course-name {
-				display: inline;
+				/* display: inline;
 				word-wrap: break-word;
-				overflow-wrap: break-word;
+				overflow-wrap: break-word; */
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
 			}
 
 			.date, .assessment-type {
 				display: inline;
+			}
+
+			.assessment-details {
+				margin-top: 0.2rem;
 			}
 		</style>
 			<div class="activity-info">
@@ -102,16 +113,18 @@
 					<h3 class="assessment-title">{{assessmentItem.name}}</h3>
 					<div class="assessment-info">
 						<div class="course-name">{{assessmentItem.courseName}}</div>
-						<iron-icon class="separator-icon" icon="d2l-tier1:bullet"></iron-icon>
-						<div class="assessment-type">[[_getAssessmentType(assessmentItem)]]</div>
-						<template is="dom-if" if="[[_hasDueDate(assessmentItem)]]">
-							<iron-icon class="separator-icon" icon="d2l-tier1:bullet"></iron-icon>
-							<div class="date">[[_getDueDateString(assessmentItem.dueDate)]]</div>
-						</template>
-						<template is="dom-if" if="[[_showEndDate(assessmentItem)]]">
-							<iron-icon class="separator-icon" icon="d2l-tier1:bullet"></iron-icon>
-							<div class="date">[[_getEndDateString(assessmentItem.endDate)]]</div>
-						</template>
+						<div class="assessment-details">
+							<!-- <iron-icon class="separator-icon" icon="d2l-tier1:bullet"></iron-icon> -->
+							<div class="assessment-type">[[_getAssessmentType(assessmentItem)]]</div>
+							<template is="dom-if" if="[[_hasDueDate(assessmentItem)]]">
+								<iron-icon class="separator-icon" icon="d2l-tier1:bullet"></iron-icon>
+								<div class="date">[[_getDueDateString(assessmentItem.dueDate)]]</div>
+							</template>
+							<template is="dom-if" if="[[_showEndDate(assessmentItem)]]">
+								<iron-icon class="separator-icon" icon="d2l-tier1:bullet"></iron-icon>
+								<div class="date">[[_getEndDateString(assessmentItem.endDate)]]</div>
+							</template>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/components/d2l-assessments-list.html
+++ b/components/d2l-assessments-list.html
@@ -12,12 +12,6 @@
 			.date-header {
 				background-color: var(--d2l-color-gypsum);
 			}
-
-			@media (max-width: 767px) {
-				d2l-assessments-list-item:nth-of-type(n+4) {
-					display: none;
-				}
-			}
 		</style>
 		<template is="dom-repeat" items="[[assessmentItems]]">
 			<d2l-assessments-list-item assessment-item="[[item]]"></d2l-assessments-list-item>

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -18,7 +18,10 @@
 	<template>
 		<style>
 			:host {
-				display: block;
+				display: flex;
+				flex-direction: column;
+				flex-grow: 1;
+				min-width: 0;
 			}
 
 			h2 {
@@ -103,25 +106,34 @@
 				color: var(--d2l-color-celestuba);
 			}
 
-			@media (min-width: 992px) {
+			/* @media (min-width: 992px) {
 				.view-all-assignments-link {
 					position: absolute;
 					bottom: 0;
 				}
+			} */
+
+			.wrapper {
+				flex-grow: 1;
 			}
 		</style>
 
 
-		<div class="no-upcoming-assessments"
-			 hidden$="[[!_showNoUpcomingAssessmentsMessage(_assessments, _showError)]]">
-			 [[_noUpcomingAssessments]]
+		<div class="wrapper">
+			<div class="no-upcoming-assessments"
+			 	 hidden$="[[!_showNoUpcomingAssessmentsMessage(_assessments, _showError)]]">
+			 	 [[_noUpcomingAssessments]]
+			</div>
+
+			<template is="dom-if" if="[[_showUpcomingAssessments(_assessments, _showError)]]">
+				<d2l-assessments-list assessment-items=[[_assessments]]></d2l-assessments-list>
+				<!-- <div class="no-upcoming-assessments">
+					[[_noUpcomingAssessments]]
+		  		</div> -->
+			</template>
+
+			<div hidden$="[[!_showError]]" class="error-message">[[localize('errorMessage')]]</div>
 		</div>
-
-		<template is="dom-if" if="[[_showUpcomingAssessments(_assessments, _showError)]]">
-			<d2l-assessments-list assessment-items=[[_assessments]]></d2l-assessments-list>
-		</template>
-
-		<div hidden$="[[!_showError]]" class="error-message">[[localize('errorMessage')]]</div>
 
 		<a class="view-all-assignments-link"
 			is="d2l-link"

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -106,13 +106,6 @@
 				color: var(--d2l-color-celestuba);
 			}
 
-			/* @media (min-width: 992px) {
-				.view-all-assignments-link {
-					position: absolute;
-					bottom: 0;
-				}
-			} */
-
 			.wrapper {
 				flex-grow: 1;
 			}
@@ -127,9 +120,6 @@
 
 			<template is="dom-if" if="[[_showUpcomingAssessments(_assessments, _showError)]]">
 				<d2l-assessments-list assessment-items=[[_assessments]]></d2l-assessments-list>
-				<!-- <div class="no-upcoming-assessments">
-					[[_noUpcomingAssessments]]
-		  		</div> -->
 			</template>
 
 			<div hidden$="[[!_showError]]" class="error-message">[[localize('errorMessage')]]</div>

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -279,7 +279,7 @@
 									});
 								self._setTotalCount(upcomingActivities.length);
 
-								var basicListActivities = upcomingActivities.slice(0, 4);
+								var basicListActivities = upcomingActivities.slice(0, 3);
 								self.set('_assessments', basicListActivities);
 							});
 					})

--- a/test/components/d2l-upcoming-assessments.js
+++ b/test/components/d2l-upcoming-assessments.js
@@ -104,9 +104,9 @@ describe('<d2l-upcoming-assessments>', function() {
 				});
 			});
 
-			it('should set the stored assessments to be the first four activities', function() {
+			it('should set the stored assessments to be the first three activities', function() {
 				return element._getInfo().then(function() {
-					expect(element._assessments.length).to.equal(4);
+					expect(element._assessments.length).to.equal(3);
 				});
 			});
 
@@ -261,7 +261,7 @@ describe('<d2l-upcoming-assessments>', function() {
 				});
 			});
 
-			it('should truncate the assessments at 4', function() {
+			it('should truncate the assessments at 3', function() {
 				var userUsage = {};
 				userUsage.getSubEntityByRel = sandbox.stub().returns();
 				userUsage.getLinkByRel = sandbox.stub().returns();
@@ -275,7 +275,7 @@ describe('<d2l-upcoming-assessments>', function() {
 
 				return element._getInfo()
 				.then(function() {
-					expect(element._assessments.toString()).to.equal([1, 2, 3, 4].toString());
+					expect(element._assessments.toString()).to.equal([1, 2, 3].toString());
 				});
 			});
 		});


### PR DESCRIPTION
[User story](https://rally1.rallydev.com/#/157196228032d/detail/userstory/174436574620)

Long course names are now ellipsis-ed like in the recent grades widget, and like the assignment name. The rest of the styling had to do w/ getting the widget to scale nicely in height relative to the other widgets. Also sliced upcoming work widget to 3 items because design/story now says 3 only.

![image](https://user-images.githubusercontent.com/31708409/33331116-5816306e-d426-11e7-9530-9dd196968412.png)