### PR TITLE
double the status-indicator margin to account for removal of margin:i…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "d2l-intl": "^0.4.1",
     "d2l-link": "^3.5.1",
     "d2l-page-load-progress": "^1.2.3",
-    "d2l-status-indicator": "^1.0.0",
+    "d2l-status-indicator": "^1.0.1",
     "d2l-typography": "^5.3.0",
     "fetch": "^2.0.3",
     "iron-a11y-keys": "^1.0.9",

--- a/components/d2l-all-assessments-list-item.html
+++ b/components/d2l-all-assessments-list-item.html
@@ -55,11 +55,11 @@
 			}
 
 			d2l-status-indicator:not([hidden]) {
-				margin-right: 5px;
+				margin-right: 10px;
 			}
 
 			:host-context([dir="rtl"]) d2l-status-indicator:not([hidden]) {
-				margin-left: 5px;
+				margin-left: 10px;
 				margin-right: 0px;
 			}
 


### PR DESCRIPTION
…nherit

~Requires~ Due to https://github.com/BrightspaceUI/status-indicator/pull/5, which has been released as `1.0.1`.