### PR TITLE
Use siren-parser-import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 language: node_js
-node_js: 6
+node_js: node
 dist: trusty
 sudo: required
 before_script:
 - npm run test:lint:js
 - npm run test:lint:wc
-- export CHROME_BIN=/usr/bin/google-chrome
-- wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-- sudo gdebi --non-interactive google-chrome*.deb
 script:
 - set -e
-- xvfb-run wct test --skip-plugin sauce
-- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then xvfb-run wct test --skip-plugin local; fi'
+- xvfb-run polymer test --skip-plugin sauce
+- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then xvfb-run polymer test --skip-plugin local; fi'
 - if [ "$TRAVIS_BRANCH" == "master" ]; then frauci-update-version; fi
 env:
   global:
@@ -22,10 +19,3 @@ env:
   - secure: zUID1VHKhJymz+JIyn3DaxTKiS/NaSxByUB/gbVkEQ/7VGvi9kbmJYnq3FmtCj734auLcp5KUFLUZfN2UM5GhzSzJ3hc5DRVcvGw/wWA1UX01DYrojdw/V5DQREW+v1VoG6GBme8PdHCUUE+0OzxViQsZ4y90CanS4A8T/LjLl35i0Vuq2ZKvewdzBJrk4o6e5p2+B/82//iGhIZUiPvNfEPO2c7wsZ+WiyzyQQgtOL0/MJ7EV0h+KepXpcnA84AdOZAIKdeqOfEzXVbBorFl678JGzFiHsLUSB/zKADgiRPLDPOfhpbOxf7bp6S18fjyeLeDGpEBWvfVdkm9q0eHQKJNEr1bCPBDmS+Va86yqkpXgDkSFRyyk0dErj9Fx6q/0LcGPr8WlH9M/FRDDwBUgKqs/g8BzMihlqcRDWVyt6rlEfW7Udag96iP+zYmzRk8rpaEb8FF1gBJ1oxQA4Urr9jSAHUr1qUPwj2ZBlZb+G76svS1ZA2/3LjsfqfcNWSIJA3R4sNTH2OSVZjicAItLX1JWnYFSBNT9aG+w2RR1s9xf+H9b7lUT3mSdVacQ4GcYfX1hQrN9e2jtAisPFYd2aL6qjnXSrcAHtAuN7zUzcEW0DfhrKpiLpYwbpKnToemRS4C57djPGDh00Ylb7iGjQHu9CLADtFdK13N2N9SBo=
   #GITHUB_RELEASE_TOKEN
   - secure: FtoFWKq4wO/I3lTnzAnMSEQ3pn3/clOuQr4d7Qpli3tkHgMqbWDOFOL4+uD7Nlc+Oza+qWWzl+w2gOz+7QCRb1YJl1TgO2DjNEsSGIeGgs1+kbI3lb2fq2KWCK+VFBrWyAsOZ5e1ppYOA7coVoDppLdLswLqESyRB1+tT2AxLYcy21TbHC2JrNCPqFatgzqovf0rJoD6vCKPdYOoQpVcLbGM0DXTeIFslON107w7j2WkYPtZcq/TINNQD2hIAoKzvM2/fzI85oFzO4chIbUvl7p2Wf5TWHCYd8FWyv45xc7tBUH4AXYae6LD/+X8JlTrmYtdoRbt6tcbnHSAswAkq2iL/PG41hWnZ/D8w5An48qvvFgO5/dfnTqcZ9hDw7ExaxV2UvWWC0vK31Trvc724sRhEEV3Mlbpcop+t0QbGpFfnVhG+P6ZMFbyyM7UVxqAKQI1oR1nPfXhOtOVsyRPRkd2n4Ht8BZY6bIZdr74x1baxyvJzauMycg0oic1y6hth3iRkf1eaVPh/OZuSd1BHFOsZqe/cmOLFfDcA/tz+ECr5jeXcM00qhGHwsSkVLMgKNKr+yH1pC40Bgvk73hMwMhmCzXFuo2ernzHlBfIloZTqeSmYvteDqdGFUKQKKSUEpUedWzFxUSRWVxO4/9PcsyPktdLDUC/x/QkOIBM+h0=
-addons:
-  firefox: latest
-  apt:
-    packages:
-    - gdebi
-    - oracle-java8-installer
-    - oracle-java8-set-default

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -1,9 +1,9 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../d2l-fetch-siren-entity-behavior/d2l-fetch-siren-entity-behavior.html">
 <link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
+<link rel="import" href="../../siren-parser-import/siren-parser.html">
 <link rel="import" href="./date-behavior.html">
 
-<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
 <script>
 	'use strict';
 

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,8 @@
     "iron-a11y-keys": "^1.0.9",
     "iron-icon": "^1.0.12",
     "polymer": "Polymer/polymer#^1.9.2",
-    "vaadin-date-picker": "~1.2.3"
+    "vaadin-date-picker": "~1.2.3",
+    "siren-parser-import": "Brightspace/siren-parser-import#^7.0.0"
   },
   "devDependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",

--- a/components/d2l-all-assessments.html
+++ b/components/d2l-all-assessments.html
@@ -11,7 +11,6 @@
 <link rel="import" href="d2l-all-assessments-list.html">
 <link rel="import" href="d2l-assessments-list.html">
 <link rel="import" href="d2l-date-dropdown.html">
-<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
 
 <dom-module id="d2l-all-assessments">
 	<template>

--- a/components/d2l-upcoming-assessments.html
+++ b/components/d2l-upcoming-assessments.html
@@ -133,7 +133,6 @@
 		</a>
 	</template>
 
-	<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
 	<script>
 		'use strict';
 

--- a/test/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/test/behaviors/d2l-upcoming-assessments-behavior.html
@@ -7,6 +7,7 @@
 		<script src="../../../web-component-tester/browser.js"></script>
 
 		<link rel="import" href="d2l-upcoming-assessments-behavior-consumer.html">
+		<link rel="import" href="../../../siren-parser-import/siren-parser.html">
 	</head>
 	<body>
 		<test-fixture id="d2l-upcoming-assessments-behavior-fixture">

--- a/test/index.html
+++ b/test/index.html
@@ -3,9 +3,8 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
-		<script src="../node_modules/web-component-tester/browser.js"></script>
-		<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
 	</head>
 	<body>
 		<script>


### PR DESCRIPTION
This allows for correct versioning of the script to avoid nasty surprises about which version is actually being fetched. Also removed direct references to the CDN script where they weren't needed.