### PR TITLE
Use the latest fetch-siren-entity-behavior

### DIFF
--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -342,7 +342,7 @@
 
 	window.D2L.UpcomingAssessments.UpcomingAssessmentsBehavior = [
 		window.D2L.UpcomingAssessments.DateBehavior,
-		window.D2L.FetchSirenEntityBehavior,
+		D2L.PolymerBehaviors.FetchSirenEntityBehavior,
 		window.D2L.Hypermedia.HMConstantsBehavior,
 		upcomingAssessmentsBehaviorImpl
 	];

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
     "d2l-colors": "^2.2.3",
     "d2l-date-picker": "~0.0.12",
-    "d2l-fetch-siren-entity-behavior": "Brightspace/d2l-fetch-siren-entity-behavior#^3.0.0",
+    "d2l-fetch-siren-entity-behavior": "Brightspace/d2l-fetch-siren-entity-behavior#^4.0.0",
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^3.0.0",
     "d2l-icons": "^3.1.2",
     "d2l-intl": "^0.4.1",


### PR DESCRIPTION
The `3.X.X` version of `fetch-siren-entity-behavior` uses the `6.X.X` of the `siren-parser`, right from the Brightspace CDN. Now that we've moved to `siren-parser-import 7.X.X` we need to move this up to the latest to avoid collision.