### PR TITLE
Skip unsupported user activity usages

### DIFF
--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -143,7 +143,13 @@
 			overdueUserUsages = overdueUserUsages.concat(overdueAssignments);
 			overdueUserUsages = overdueUserUsages.concat(overdueQuizzes);
 
-			userActivityUsages.entities.forEach(function(userActivityUsage) {
+			var assignmentUserUsages = userActivityUsages.getSubEntitiesByClass(self.HypermediaClasses.activities.userAssignmentActivity);
+			var quizUserUsages = userActivityUsages.getSubEntitiesByClass(self.HypermediaClasses.activities.userQuizActivity);
+			var supportedUserUsages = [];
+			supportedUserUsages = supportedUserUsages.concat(assignmentUserUsages);
+			supportedUserUsages = supportedUserUsages.concat(quizUserUsages);
+
+			supportedUserUsages.forEach(function(userActivityUsage) {
 				var organizationRequest = self._getOrganizationRequest.call(self, userActivityUsage, getToken, userUrl);
 				var activityRequest = self._getActivityRequest.call(self, userActivityUsage, getToken, userUrl);
 

--- a/test/behaviors/d2l-upcoming-assessments-behavior.js
+++ b/test/behaviors/d2l-upcoming-assessments-behavior.js
@@ -325,6 +325,17 @@ describe('d2l upcoming assessments behavior', function() {
 			component._getActivityRequest = sandbox.stub().returns(Promise.resolve(activity));
 		});
 
+		it('should ignore non-supported user activity usages', function() {
+			userUsage = getUserActivityUsage('unsupported');
+			userUsages = parse({ entities: [userUsage] });
+
+			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
+				.then(function() {
+					expect(component._getOrganizationRequest).to.have.not.been.called;
+					expect(component._getActivityRequest).to.have.not.been.called;
+				});
+		});
+
 		it('should call _getOrganizationRequest for the organization', function() {
 			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
 				.then(function() {


### PR DESCRIPTION
This came up in testing the discussions activities API - due to `_getActivityRequest` explicitly looking for an assignment or quiz, we end up trying to fetching undefined URLs, and then bad things happen. Instead, take a similar approach that is being done with the overdue activities already - filter the user activity usages down to only the types we know how to handle up front, and avoid said bad things!