### PR TITLE
Make sure to return endDate as string to be same as dueDate

### DIFF
--- a/behaviors/status-badge-behavior.html
+++ b/behaviors/status-badge-behavior.html
@@ -126,7 +126,7 @@
 			return {
 				isEnded: activityDate < now,
 				endsToday: this.getDateDiffInCalendarDays(endDate) === 0,
-				date: activityDate
+				date: endDate
 			};
 		},
 	};


### PR DESCRIPTION
[DE30994 - Closed quizzes do not sort correctly in upcoming work list](https://rally1.rallydev.com/#/157196228032d/detail/defect/245133560576)

The `dueDate` is being returned as a string but the `endDate` was a date object. This led to incorrect comparisoning. I would have switched the `dueDate` to be a proper date to match `endDate` but that caused deeper problems with other places `new Date()`-ing the dueDate because these have traditionally been strings, so this was the safer fix.