### PR TITLE
DE31336 - Don't load module user activity usages into the widget

### DIFF
--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -92,6 +92,9 @@
 			this._allTypes.forEach(function(typeString) {
 				var type = this._types[typeString];
 				var entities = usageList.getSubEntitiesByClass(type.userActivityUsageClass);
+				if (type.filterUsages) {
+					entities = entities.filter(type.filterUsages.bind(this));
+				}
 				usages = usages.concat(entities);
 			}.bind(this));
 			return usages;

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -93,7 +93,7 @@
 				var type = this._types[typeString];
 				var entities = usageList.getSubEntitiesByClass(type.userActivityUsageClass);
 				if (type.usagePredicate) {
-					entities = entities.filter(type.usagePredicate.bind(this));
+					entities = entities.filter(type.usagePredicate);
 				}
 				usages = usages.concat(entities);
 			}.bind(this));

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -92,8 +92,8 @@
 			this._allTypes.forEach(function(typeString) {
 				var type = this._types[typeString];
 				var entities = usageList.getSubEntitiesByClass(type.userActivityUsageClass);
-				if (type.filterUsages) {
-					entities = entities.filter(type.filterUsages.bind(this));
+				if (type.usagePredicate) {
+					entities = entities.filter(type.usagePredicate.bind(this));
 				}
 				usages = usages.concat(entities);
 			}.bind(this));

--- a/behaviors/types-behavior.html
+++ b/behaviors/types-behavior.html
@@ -61,6 +61,9 @@
 							canOpen: false,
 							instructionsRel: this.HypermediaRels.Content.description,
 							userActivityUsageClass: this.HypermediaClasses.activities.userContentActivity,
+							filterUsages: function(userActivityUsage) {
+								return userActivityUsage && userActivityUsage.hasClass(this.HypermediaClasses.content.topic);
+							},
 							activityRel: this.HypermediaRels.content,
 							activityClass: this.HypermediaClasses.content.sequencedActivity,
 							noCompletion: false,

--- a/behaviors/types-behavior.html
+++ b/behaviors/types-behavior.html
@@ -63,7 +63,7 @@
 							userActivityUsageClass: this.HypermediaClasses.activities.userContentActivity,
 							usagePredicate: function(userActivityUsage) {
 								return userActivityUsage && userActivityUsage.hasClass(this.HypermediaClasses.content.topic);
-							},
+							}.bind(this),
 							activityRel: this.HypermediaRels.content,
 							activityClass: this.HypermediaClasses.content.sequencedActivity,
 							noCompletion: false,

--- a/behaviors/types-behavior.html
+++ b/behaviors/types-behavior.html
@@ -61,7 +61,7 @@
 							canOpen: false,
 							instructionsRel: this.HypermediaRels.Content.description,
 							userActivityUsageClass: this.HypermediaClasses.activities.userContentActivity,
-							filterUsages: function(userActivityUsage) {
+							usagePredicate: function(userActivityUsage) {
 								return userActivityUsage && userActivityUsage.hasClass(this.HypermediaClasses.content.topic);
 							},
 							activityRel: this.HypermediaRels.content,

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "d2l-colors": "^3.1.2",
     "d2l-date-picker": "BrightspaceUI/date-picker#^1.0.0",
     "d2l-fetch-siren-entity-behavior": "Brightspace/d2l-fetch-siren-entity-behavior#^5.0.2",
-    "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^5.7.0",
+    "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^5.19.4",
     "d2l-icons": "^4.14.2",
     "d2l-link": "^4.0.0",
     "d2l-page-load-progress": "^2.0.1",

--- a/test/behaviors/d2l-upcoming-assessments-behavior.js
+++ b/test/behaviors/d2l-upcoming-assessments-behavior.js
@@ -35,7 +35,12 @@ describe('d2l upcoming assessments behavior', function() {
 		return window.D2L.Hypermedia.Siren.Parse(entity);
 	}
 
-	function getUserActivityUsage(type, isComplete, isExempt) {
+	function getUserActivityUsage(type, isComplete, isExempt, isModuleContent) {
+		var classList = ['activity', 'user-' + type + '-activity'];
+		if (isExempt) {
+			classList.push('exempt');
+		}
+
 		var activityRel;
 		if (type === 'quiz') {
 			activityRel = 'https://api.brightspace.com/rels/quiz';
@@ -43,13 +48,9 @@ describe('d2l upcoming assessments behavior', function() {
 			activityRel = 'https://api.brightspace.com/rels/assignment';
 		} else if (type === 'content') {
 			activityRel = 'https://api.brightspace.com/rels/content';
+			classList.push(isModuleContent ? 'module' : 'topic');
 		} else if (type === 'discussion') {
 			activityRel = 'https://discussions.api.brightspace.com/rels/topic';
-		}
-
-		var classList = ['activity', 'user-' + type + '-activity'];
-		if (isExempt) {
-			classList.push('exempt');
 		}
 
 		var entity = {
@@ -379,6 +380,28 @@ describe('d2l upcoming assessments behavior', function() {
 				.then(function() {
 					expect(component._getOrganizationRequest).to.have.not.been.called;
 					expect(component._getActivityRequest).to.have.not.been.called;
+				});
+		});
+
+		it('should ignore content module user activity usages', function() {
+			userUsage = getUserActivityUsage('content', false, false, true);
+			userUsages = parse({ entities: [userUsage] });
+
+			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
+				.then(function() {
+					expect(component._getOrganizationRequest).to.have.not.been.called;
+					expect(component._getActivityRequest).to.have.not.been.called;
+				});
+		});
+
+		it('should include content topic user activity usages', function() {
+			userUsage = getUserActivityUsage('content', false, false, false);
+			userUsages = parse({ entities: [userUsage] });
+
+			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
+				.then(function() {
+					expect(component._getOrganizationRequest).to.have.been.called;
+					expect(component._getActivityRequest).to.have.been.called;
 				});
 		});
 


### PR DESCRIPTION
We don't want to show modules, but we were loading them in anyways and that was causing things to crash

Needs:
https://git.dev.d2l/projects/CORE/repos/le/pull-requests/11940/overview
https://github.com/Brightspace/d2l-hm-constants-behavior/pull/65
