### PR TITLE
Update Mac safari sauce settings

### DIFF
--- a/wct.conf.json
+++ b/wct.conf.json
@@ -23,7 +23,7 @@
         {
           "browserName": "safari",
           "platform": "OS X 10.13",
-          "version": ""
+          "version": "11.1"
         },
         {
           "browserName": "microsoftedge",


### PR DESCRIPTION
As mentioned in Slack Sauce is having trouble with Safari 12. Per Dave L:

>if anyone is getting Sauce errors with Safari, change your `wct.conf.js` file to explicitly set `OSX 10.13` as the OS version (should be there already) and `11.1` as the Safari version.

>I’m raising a ticket with Sauce Labs to make sure they’re aware of the lack of version 12 support.