### PR TITLE
Add surveys/checklists

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
   },
   "globals": {
     "Promise": false,
-    "Map": false
+    "Map": false,
+    "Set": false
   }
 }

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -88,18 +88,7 @@
 		},
 
 		_concatActivityUsageTypes: function(usageList) {
-			var usages = [];
-			this._allTypes.forEach(function(typeString) {
-				var type = this._types[typeString];
-				var entities = usageList.filter(function(usage) {
-					return usage.hasClass(type.userActivityUsageClass);
-				});
-				if (type.usagePredicate) {
-					entities = entities.filter(type.usagePredicate);
-				}
-				usages = usages.concat(entities);
-			}.bind(this));
-			return usages;
+			return usageList.filter(this._isSupportedType.bind(this));
 		},
 
 		_getActivityStatus: function(type, userActivityUsage, overdueUserUsages) {
@@ -360,7 +349,9 @@
 				activityEntities = activities.entities || [];
 			}
 
-			var activitiesContext = this._createNormalizedEntityMap(activityEntities);
+			var supportedActivities = activityEntities.filter(this._isSupportedType.bind(this));
+
+			var activitiesContext = this._createNormalizedEntityMap(supportedActivities);
 			var flattenedActivities = Array.from(activitiesContext.activitiesMap.values());
 
 			return self._hydrateActivityEntities(flattenedActivities)
@@ -372,42 +363,36 @@
 					// Normalize activity data prior to deduping; eg, some activities don't
 					// have a due date (surveys), while the content topic can
 					hydratedActivities.forEach(function(activity) {
-						var isChanged = false;
+						var canonicalActivity = activity;
 
 						if (parentActivitiesMap.has(activity.getLinkByRel('self').href)) {
 							var parentActivity = parentActivitiesMap.get(activity.getLinkByRel('self').href);
 
+							// There are cases where a content topic child activity (eg. a survey activity) doesn't
+							// have the same set of restrictions as the content topic itself. Because we only want to
+							// display one version of the same logical activity, we'll use the child activity,
+							// but ensure it has the superset of data from the content topic (due date).
+							// Since our data model is currently based on the LMS Siren entities,
+							// create and parse a new synthetic entity.
 							if (!activity.hasEntityByClass('due-date') && parentActivity.hasEntityByClass('due-date')) {
 								var parentDueDate = parentActivity.getSubEntityByClass('due-date');
 
-								Array.isArray(activity.entities)
-									? activity.entities.push(parentDueDate)
-									: activity.entities = [parentDueDate];
-
-								isChanged = true;
+								// Create new object with updated helper functions
+								canonicalActivity = window.D2L.Hypermedia.Siren.Parse({
+									class: activity.class,
+									rel: activity.rel,
+									entities: [parentDueDate].concat(activity.entities || []),
+									actions: activity.actions,
+									links: activity.links
+								});
 							}
 
-							// We support the child activity directly, so delete parent content topic
+							// Ensure we only have a single representation of the same logical activity,
+							// preferring the child activity
 							redundantActivities.push(parentActivity.getLinkByRel('self').href);
 						}
 
-						// Since downstream logic depends on Siren for the component's data model,
-						// we need to re-parse when we've added entities/links/actions so that helper
-						// functions are updated. Not great, but should be rare, and a good case for
-						// abstracting from Siren a bit more.
-						// Also need to create new object, as node-siren-parser might have guards for
-						// re-parsing in some cases..
-						var activityToSave = isChanged
-							? window.D2L.Hypermedia.Siren.Parse({
-								class: activity.class,
-								rel: activity.rel,
-								entities: activity.entities,
-								actions: activity.actions,
-								links: activity.links
-							})
-							: activity;
-
-						activitiesMap.set(activity.getLinkByRel('self').href, activityToSave);
+						activitiesMap.set(activity.getLinkByRel('self').href, canonicalActivity);
 					});
 
 					return Array.from(activitiesMap.values())
@@ -441,11 +426,8 @@
 
 						parentActivitiesMap.set(childSelfLink, activity);
 
-						for (var index = 0; index < self._activityTypes.length; index++) {
-							if (childActivity.hasClass(self._activityTypes[index])) {
-								allActivities.push(childActivity);
-								break;
-							}
+						if (self._isSupportedType(childActivity)) {
+							allActivities.push(childActivity);
 						}
 					}
 
@@ -501,6 +483,20 @@
 
 					return hydratedActivities;
 				});
+		},
+
+		_isSupportedType: function(usage) {
+			var self = this;
+
+			return this._allTypes.some(function(typeString) {
+				var type = self._types[typeString];
+
+				if (usage.hasClass(type.userActivityUsageClass)) {
+					return type.usagePredicate
+						? type.usagePredicate(usage)
+						: true;
+				}
+			});
 		}
 	};
 

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -340,7 +340,7 @@
 		* parent content activity are projected onto the child activity when missing.
 		*/
 		_flattenActivities: function(activities) {
-			var activityEntities = [];
+			var activityEntities;
 			var self = this;
 
 			if (Array.isArray(activities)) {
@@ -364,9 +364,10 @@
 					// have a due date (surveys), while the content topic can
 					hydratedActivities.forEach(function(activity) {
 						var canonicalActivity = activity;
+						var activitySelfLink = activity.getLinkByRel('self').href;
 
-						if (parentActivitiesMap.has(activity.getLinkByRel('self').href)) {
-							var parentActivity = parentActivitiesMap.get(activity.getLinkByRel('self').href);
+						if (parentActivitiesMap.has(activitySelfLink)) {
+							var parentActivity = parentActivitiesMap.get(activitySelfLink);
 
 							// There are cases where a content topic child activity (eg. a survey activity) doesn't
 							// have the same set of restrictions as the content topic itself. Because we only want to
@@ -381,6 +382,7 @@
 								canonicalActivity = window.D2L.Hypermedia.Siren.Parse({
 									class: activity.class,
 									rel: activity.rel,
+									properties: activity.properties,
 									entities: [parentDueDate].concat(activity.entities || []),
 									actions: activity.actions,
 									links: activity.links
@@ -392,12 +394,12 @@
 							redundantActivities.push(parentActivity.getLinkByRel('self').href);
 						}
 
-						activitiesMap.set(activity.getLinkByRel('self').href, canonicalActivity);
+						activitiesMap.set(activitySelfLink, canonicalActivity);
 					});
 
 					return Array.from(activitiesMap.values())
-						.filter(function(activityHref) {
-							return !redundantActivities.includes(activityHref.getLinkByRel('self').href);
+						.filter(function(activity) {
+							return !redundantActivities.includes(activity.getLinkByRel('self').href);
 						});
 				});
 		},
@@ -439,11 +441,9 @@
 				var selfLink = (activityEntity.getLinkByRel('self') || {}).href
 					|| activityEntity.href;
 
-				if (activitiesMap.has(selfLink)) {
-					if (activitiesMap.get(selfLink).href !== undefined) {
-						activitiesMap.set(selfLink, activityEntity);
-					}
-				} else {
+				// Save the entity if it doesn't exist, or the current representation is a linked subentity
+				// (has an href directly on the entity)
+				if (!activitiesMap.has(selfLink) || activitiesMap.get(selfLink).href !== undefined) {
 					activitiesMap.set(selfLink, activityEntity);
 				}
 			});
@@ -477,11 +477,7 @@
 
 			return Promise.all(activityPromises)
 				.then(function(entities) {
-					entities.forEach(function(entity) {
-						hydratedActivities.push(entity);
-					});
-
-					return hydratedActivities;
+					return hydratedActivities.concat(entities);
 				});
 		},
 

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -15,19 +15,6 @@
 	var upcomingAssessmentsBehaviorImpl = {
 
 		properties: {
-			_activityTypes: {
-				type: Array,
-				value: function() {
-					return [
-						this.HypermediaClasses.activities.userAssignmentActivity,
-						this.HypermediaClasses.activities.userQuizActivity,
-						this.HypermediaClasses.activities.userDiscussionActivity,
-						this.HypermediaClasses.activities.userContentActivity,
-						this.HypermediaClasses.activities.userChecklistActivity,
-						this.HypermediaClasses.activities.userSurveyActivity
-					];
-				}
-			},
 			userUrl: String,
 			getToken: {
 				type: Object,
@@ -380,31 +367,53 @@
 				.then(function(hydratedActivities) {
 					var activitiesMap = activitiesContext.activitiesMap;
 					var parentActivitiesMap = activitiesContext.parentActivitiesMap;
+					var redundantActivities = [];
 
 					// Normalize activity data prior to deduping; eg, some activities don't
 					// have a due date (surveys), while the content topic can
 					hydratedActivities.forEach(function(activity) {
+						var isChanged = false;
+
 						if (parentActivitiesMap.has(activity.getLinkByRel('self').href)) {
 							var parentActivity = parentActivitiesMap.get(activity.getLinkByRel('self').href);
 
-							if (activity.getSubEntitiesByClass('due-date').length === 0) {
-								var parentDueDates = parentActivity.getSubEntitiesByClass('due-date');
+							if (!activity.hasEntityByClass('due-date') && parentActivity.hasEntityByClass('due-date')) {
+								var parentDueDate = parentActivity.getSubEntityByClass('due-date');
 
-								if (parentDueDates.length > 0) {
-									Array.isArray(activity.entities)
-										? activity.entities.push(parentDueDates[0])
-										: activity.entities = [parentDueDates[0]];
-								}
+								Array.isArray(activity.entities)
+									? activity.entities.push(parentDueDate)
+									: activity.entities = [parentDueDate];
+
+								isChanged = true;
 							}
 
 							// We support the child activity directly, so delete parent content topic
-							activitiesMap.delete(parentActivity.getLinkByRel('self').href);
+							redundantActivities.push(parentActivity.getLinkByRel('self').href);
 						}
 
-						activitiesMap.set(activity.getLinkByRel('self').href, activity);
+						// Since downstream logic depends on Siren for the component's data model,
+						// we need to re-parse when we've added entities/links/actions so that helper
+						// functions are updated. Not great, but should be rare, and a good case for
+						// abstracting from Siren a bit more.
+						// Also need to create new object, as node-siren-parser might have guards for
+						// re-parsing in some cases..
+						var activityToSave = isChanged
+							? window.D2L.Hypermedia.Siren.Parse({
+								class: activity.class,
+								rel: activity.rel,
+								entities: activity.entities,
+								actions: activity.actions,
+								links: activity.links
+							})
+							: activity;
+
+						activitiesMap.set(activity.getLinkByRel('self').href, activityToSave);
 					});
 
-					return Promise.resolve(Array.from(activitiesMap.values()));
+					return Array.from(activitiesMap.values())
+						.filter(function(activityHref) {
+							return !redundantActivities.includes(activityHref.getLinkByRel('self').href);
+						});
 				});
 		},
 
@@ -414,35 +423,36 @@
 			var allActivities = [];
 			var self = this;
 
-			activityEntities = activityEntities.map(function(entity) {
-				return window.D2L.Hypermedia.Siren.Parse(entity);
-			});
+			activityEntities
+				.map(window.D2L.Hypermedia.Siren.Parse)
+				.forEach(function(activity) {
+					var childActivity = activity.getSubEntityByRel(self.HypermediaRels.Activities.childUserActivityUsage);
 
-			activityEntities.forEach(function(activity) {
-				var sirenActivity = window.D2L.Hypermedia.Siren.Parse(activity);
-				var childActivity = sirenActivity.getSubEntityByRel(self.HypermediaRels.Activities.childUserActivityUsage);
+					if (childActivity) {
+						// @NOTE: Possible bug in node-siren-parser means linked subentities don't have
+						// helper functions, so, re-parse if so.
+						if (childActivity.href) {
+							var childActivityHref = childActivity.href; // Save because parsing it in isolation dumps this..
+							childActivity =  window.D2L.Hypermedia.Siren.Parse(childActivity);
+							childActivity.href = childActivityHref;
+						}
 
-				if (childActivity) {
-					var childActivityHref = childActivity.href; // Save because parsing it dumps this..
-					childActivity =  window.D2L.Hypermedia.Siren.Parse(childActivity);
-					childActivity.href = childActivityHref;
+						var childSelfLink = childActivity.href || (childActivity.getLinkByRel('self') || {}).href;
 
-					var childSelfLink = childActivity.href || (childActivity.getLinkByRel('self') || {}).href;
+						parentActivitiesMap.set(childSelfLink, activity);
 
-					parentActivitiesMap.set(childSelfLink, sirenActivity);
-
-					for (var index = 0; index < self._activityTypes.length; index++) {
-						if (childActivity.hasClass(self._activityTypes[index])) {
-							allActivities.push(childActivity);
-							break;
+						for (var index = 0; index < self._activityTypes.length; index++) {
+							if (childActivity.hasClass(self._activityTypes[index])) {
+								allActivities.push(childActivity);
+								break;
+							}
 						}
 					}
-				}
 
-				allActivities.push(sirenActivity);
-			});
+					allActivities.push(activity);
+				});
 
-			// Flatten activities, preferring already-hydrated version of any entities
+			// Dedupe activities, preferring already-hydrated version of any entities
 			allActivities.forEach(function(activityEntity) {
 				var selfLink = (activityEntity.getLinkByRel('self') || {}).href
 					|| activityEntity.href;
@@ -476,13 +486,11 @@
 
 			var activityPromises = activityEntities
 				.filter(function(entity) {
-					return !!entity.href;
+					return entity.href;
 				})
 				.map(function(entity) {
 					return self._fetchEntityWithToken(entity.href, self.getToken, self.userUrl)
-						.then(function(entity) {
-							return Promise.resolve(window.D2L.Hypermedia.Siren.Parse(entity));
-						});
+						.then(window.D2L.Hypermedia.Siren.Parse);
 				});
 
 			return Promise.all(activityPromises)
@@ -491,7 +499,7 @@
 						hydratedActivities.push(entity);
 					});
 
-					return Promise.resolve(hydratedActivities);
+					return hydratedActivities;
 				});
 		}
 	};

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -15,6 +15,19 @@
 	var upcomingAssessmentsBehaviorImpl = {
 
 		properties: {
+			_activityTypes: {
+				type: Array,
+				value: function() {
+					return [
+						this.HypermediaClasses.activities.userAssignmentActivity,
+						this.HypermediaClasses.activities.userQuizActivity,
+						this.HypermediaClasses.activities.userDiscussionActivity,
+						this.HypermediaClasses.activities.userContentActivity,
+						this.HypermediaClasses.activities.userChecklistActivity,
+						this.HypermediaClasses.activities.userSurveyActivity
+					];
+				}
+			},
 			userUrl: String,
 			getToken: {
 				type: Object,
@@ -91,7 +104,9 @@
 			var usages = [];
 			this._allTypes.forEach(function(typeString) {
 				var type = this._types[typeString];
-				var entities = usageList.getSubEntitiesByClass(type.userActivityUsageClass);
+				var entities = usageList.filter(function(usage) {
+					return usage.hasClass(type.userActivityUsageClass);
+				});
 				if (type.usagePredicate) {
 					entities = entities.filter(type.usagePredicate);
 				}
@@ -119,7 +134,7 @@
 		* Returns an object that contains the information required to populate an assessment list item
 		*/
 		_getUserActivityUsagesInfos: function(userActivityUsages, overdueUserActivityUsages, getToken, userUrl) {
-			if (!userActivityUsages.entities) {
+			if (!Array.isArray(userActivityUsages) || userActivityUsages.length === 0) {
 				return;
 			}
 
@@ -278,7 +293,20 @@
 					self._periodStart = userActivityUsages.properties.start;
 					self._periodEnd = userActivityUsages.properties.end;
 
-					return self._getUserActivityUsagesInfos(userActivityUsages, overdueUserActivityUsages, self.getToken, self.userUrl);
+					var flattenActivityUsages = self._flattenActivities(userActivityUsages);
+					var flattenOverdueActivityUsages = self._flattenActivities(overdueUserActivityUsages);
+
+					return Promise.all([
+						flattenActivityUsages,
+						flattenOverdueActivityUsages
+					]).then(function(responses) {
+						return self._getUserActivityUsagesInfos(
+							responses[0],
+							responses[1],
+							self.getToken,
+							self.userUrl
+						);
+					});
 				})
 				.then(function(userActivityUsagesInfos) {
 					var activities = self._updateActivitiesInfo(userActivityUsagesInfos, self.getToken, self.userUrl);
@@ -326,6 +354,153 @@
 			this._nextPeriodUrl = null;
 			this._periodStart = null;
 			this._periodEnd = null;
+		},
+
+		/*
+		* Returns a flattened list of user-activity-usages, deduplicating where necessary
+		* If a user-content-activity points to a supported domain-specific user-activity-usage,
+		* that content activity is removed, and only the domain activity is added.
+		* Linked subentities are hydrated, and the date restrictions of the
+		* parent content activity are projected onto the child activity when missing.
+		*/
+		_flattenActivities: function(activities) {
+			var activitiesMap = new Map();
+			var parentActivitiesMap = new Map();
+			var allActivities = [];
+			var activityEntities = [];
+			var self = this;
+
+			if (Array.isArray(activities)) {
+				activityEntities = activities;
+			} else {
+				activityEntities = activities.entities || [];
+			}
+
+			activityEntities = activityEntities.map(function(entity) {
+				return window.D2L.Hypermedia.Siren.Parse(entity);
+			});
+
+			activityEntities.forEach(function(activity) {
+				var sirenActivity = window.D2L.Hypermedia.Siren.Parse(activity);
+				var childActivity = sirenActivity.getSubEntityByRel('https://activities.api.brightspace.com/rels/child-user-activity-usage');
+
+				if (childActivity) {
+					var childActivityHref = childActivity.href; // Save because parsing it dumps this..
+					childActivity =  window.D2L.Hypermedia.Siren.Parse(childActivity);
+					childActivity.href = childActivityHref;
+
+					var childSelfLink = childActivity.href || (childActivity.getLinkByRel('self') || {}).href;
+
+					parentActivitiesMap.set(childSelfLink, sirenActivity);
+
+					for (var index = 0; index < self._activityTypes.length; index++) {
+						if (childActivity.hasClass(self._activityTypes[index])) {
+							allActivities.push(childActivity);
+							break;
+						}
+					}
+				}
+
+				allActivities.push(sirenActivity);
+			});
+
+			// Flatten activities, preferring already-hydrated version of any entities
+			allActivities.forEach(function(activityEntity) {
+				var selfLink = (activityEntity.getLinkByRel('self') || {}).href
+					|| activityEntity.href;
+
+				if (activitiesMap.has(selfLink)) {
+					if (activitiesMap.get(selfLink).href !== undefined) {
+						activitiesMap.set(selfLink, activityEntity);
+					}
+				} else {
+					activitiesMap.set(selfLink, activityEntity);
+				}
+			});
+
+			return this._hydrateActivityEntities(Array.from(activitiesMap.values()))
+				.then(function(hydratedActivities) {
+					var activitiesToRemove = new Set();
+
+					// Normalize activity data prior to deduping; eg, some activities don't
+					// have a due date (surveys), while the content topic can
+					hydratedActivities
+						.forEach(function(activity) {
+							if (parentActivitiesMap.has(activity.getLinkByRel('self').href)) {
+								var parentActivity = parentActivitiesMap.get(activity.getLinkByRel('self').href);
+
+								if (activity.getSubEntitiesByClass('due-date').length === 0) {
+									var parentDueDates = parentActivity.getSubEntitiesByClass('due-date');
+
+									if (parentDueDates.length > 0) {
+										Array.isArray(activity.entities)
+											? activity.entities.push(parentDueDates[0])
+											: activity.entities = [parentDueDates[0]];
+									}
+								}
+
+								activitiesToRemove.add(parentActivity.getLinkByRel('self').href);
+							}
+
+							activitiesMap.set(activity.getLinkByRel('self').href, activity);
+						});
+
+					// If an activity is a child of a content activity,
+					// and we directly support the child entity activity type,
+					// remove the content entity.
+					Array.from(activitiesToRemove)
+						.forEach(function(activityHref) {
+							activitiesMap.delete(activityHref);
+						});
+
+					// Ensure all entities have helpers
+					var parsedPopulatedEntities = Array.from(activitiesMap.values())
+						.map(function(currActivity) {
+							return window.D2L.Hypermedia.Siren.Parse({
+								class: currActivity.class,
+								rel: currActivity.rel,
+								entities: currActivity.entities,
+								links: currActivity.links,
+								actions: currActivity.actions,
+								href: currActivity.href
+							});
+						});
+
+					return Promise.resolve(parsedPopulatedEntities);
+				});
+		},
+
+		/*
+		* On success, all activities, with linked subentities hydrated
+		*/
+		_hydrateActivityEntities: function(activityEntities) {
+			var self = this;
+
+			// Already-complete entities
+			var hydratedActivities = activityEntities
+				.filter(function(entity) {
+					return !entity.href;
+				});
+
+			var activityPromises = activityEntities
+				.filter(function(entity) {
+					return !!entity.href;
+				})
+				.map(function(entity) {
+					return self._fetchEntityWithToken(entity.href, self.getToken, self.userUrl)
+						.then(function(entity) {
+							return Promise.resolve(window.D2L.Hypermedia.Siren.Parse(entity));
+						});
+				});
+
+			return Promise.all(activityPromises)
+				.then(function(entities) {
+					entities.forEach(function(entity) {
+						hydratedActivities.push(entity);
+					});
+
+					return Promise.resolve(hydratedActivities);
+				});
 		}
 	};
 

--- a/behaviors/d2l-upcoming-assessments-behavior.html
+++ b/behaviors/d2l-upcoming-assessments-behavior.html
@@ -364,9 +364,6 @@
 		* parent content activity are projected onto the child activity when missing.
 		*/
 		_flattenActivities: function(activities) {
-			var activitiesMap = new Map();
-			var parentActivitiesMap = new Map();
-			var allActivities = [];
 			var activityEntities = [];
 			var self = this;
 
@@ -376,13 +373,54 @@
 				activityEntities = activities.entities || [];
 			}
 
+			var activitiesContext = this._createNormalizedEntityMap(activityEntities);
+			var flattenedActivities = Array.from(activitiesContext.activitiesMap.values());
+
+			return self._hydrateActivityEntities(flattenedActivities)
+				.then(function(hydratedActivities) {
+					var activitiesMap = activitiesContext.activitiesMap;
+					var parentActivitiesMap = activitiesContext.parentActivitiesMap;
+
+					// Normalize activity data prior to deduping; eg, some activities don't
+					// have a due date (surveys), while the content topic can
+					hydratedActivities.forEach(function(activity) {
+						if (parentActivitiesMap.has(activity.getLinkByRel('self').href)) {
+							var parentActivity = parentActivitiesMap.get(activity.getLinkByRel('self').href);
+
+							if (activity.getSubEntitiesByClass('due-date').length === 0) {
+								var parentDueDates = parentActivity.getSubEntitiesByClass('due-date');
+
+								if (parentDueDates.length > 0) {
+									Array.isArray(activity.entities)
+										? activity.entities.push(parentDueDates[0])
+										: activity.entities = [parentDueDates[0]];
+								}
+							}
+
+							// We support the child activity directly, so delete parent content topic
+							activitiesMap.delete(parentActivity.getLinkByRel('self').href);
+						}
+
+						activitiesMap.set(activity.getLinkByRel('self').href, activity);
+					});
+
+					return Promise.resolve(Array.from(activitiesMap.values()));
+				});
+		},
+
+		_createNormalizedEntityMap: function(activityEntities) {
+			var activitiesMap = new Map();
+			var parentActivitiesMap = new Map();
+			var allActivities = [];
+			var self = this;
+
 			activityEntities = activityEntities.map(function(entity) {
 				return window.D2L.Hypermedia.Siren.Parse(entity);
 			});
 
 			activityEntities.forEach(function(activity) {
 				var sirenActivity = window.D2L.Hypermedia.Siren.Parse(activity);
-				var childActivity = sirenActivity.getSubEntityByRel('https://activities.api.brightspace.com/rels/child-user-activity-usage');
+				var childActivity = sirenActivity.getSubEntityByRel(self.HypermediaRels.Activities.childUserActivityUsage);
 
 				if (childActivity) {
 					var childActivityHref = childActivity.href; // Save because parsing it dumps this..
@@ -418,56 +456,10 @@
 				}
 			});
 
-			return this._hydrateActivityEntities(Array.from(activitiesMap.values()))
-				.then(function(hydratedActivities) {
-					var activitiesToRemove = new Set();
-
-					// Normalize activity data prior to deduping; eg, some activities don't
-					// have a due date (surveys), while the content topic can
-					hydratedActivities
-						.forEach(function(activity) {
-							if (parentActivitiesMap.has(activity.getLinkByRel('self').href)) {
-								var parentActivity = parentActivitiesMap.get(activity.getLinkByRel('self').href);
-
-								if (activity.getSubEntitiesByClass('due-date').length === 0) {
-									var parentDueDates = parentActivity.getSubEntitiesByClass('due-date');
-
-									if (parentDueDates.length > 0) {
-										Array.isArray(activity.entities)
-											? activity.entities.push(parentDueDates[0])
-											: activity.entities = [parentDueDates[0]];
-									}
-								}
-
-								activitiesToRemove.add(parentActivity.getLinkByRel('self').href);
-							}
-
-							activitiesMap.set(activity.getLinkByRel('self').href, activity);
-						});
-
-					// If an activity is a child of a content activity,
-					// and we directly support the child entity activity type,
-					// remove the content entity.
-					Array.from(activitiesToRemove)
-						.forEach(function(activityHref) {
-							activitiesMap.delete(activityHref);
-						});
-
-					// Ensure all entities have helpers
-					var parsedPopulatedEntities = Array.from(activitiesMap.values())
-						.map(function(currActivity) {
-							return window.D2L.Hypermedia.Siren.Parse({
-								class: currActivity.class,
-								rel: currActivity.rel,
-								entities: currActivity.entities,
-								links: currActivity.links,
-								actions: currActivity.actions,
-								href: currActivity.href
-							});
-						});
-
-					return Promise.resolve(parsedPopulatedEntities);
-				});
+			return {
+				activitiesMap: activitiesMap,
+				parentActivitiesMap: parentActivitiesMap,
+			};
 		},
 
 		/*

--- a/behaviors/types-behavior.html
+++ b/behaviors/types-behavior.html
@@ -12,6 +12,19 @@
 	*/
 	var typesBehaviorImpl = {
 		properties: {
+			_activityTypes: {
+				type: Array,
+				value: function() {
+					return [
+						this.HypermediaClasses.activities.userAssignmentActivity,
+						this.HypermediaClasses.activities.userQuizActivity,
+						this.HypermediaClasses.activities.userDiscussionActivity,
+						this.HypermediaClasses.activities.userContentActivity,
+						this.HypermediaClasses.activities.userChecklistActivity,
+						this.HypermediaClasses.activities.userSurveyActivity
+					];
+				}
+			},
 			_types: {
 				type: Object,
 				value: function() {
@@ -28,9 +41,8 @@
 							activityDetailsFeatureFlag: 'assignmentDetailsEnabled'
 						},
 						checklistItem: {
-							icon: function(assessmentItem) {
-								// checklist doesn't have a tier 3 icon
-								return assessmentItem.tier2IconKey || 'd2l-tier2:checklist';
+							icon: function() {
+								return 'd2l-tier2:checklist'; // checklist doesn't have a tier3 icon
 							},
 							assessmentType: 'checklistItem',
 							canOpen: false,
@@ -84,9 +96,8 @@
 							activityDetailsFeatureFlag: 'NOT_IMPLEMENTED'
 						},
 						survey: {
-							icon: function(assessmentItem) {
-								// survey doesn't have a tier 3 icon
-								return assessmentItem.tier2IconKey || 'd2l-tier2:surveys';
+							icon: function() {
+								return 'd2l-tier2:surveys'; // surveys doesn't have a tier3 icon
 							},
 							assessmentType: 'survey',
 							canOpen: false,

--- a/behaviors/types-behavior.html
+++ b/behaviors/types-behavior.html
@@ -34,7 +34,7 @@
 							},
 							assessmentType: 'checklistItem',
 							canOpen: false,
-							instructionsRel: 'https://checklists.api.brightspace.com/rels/description',
+							instructionsRel: this.HypermediaRels.Checklists.description,
 							userActivityUsageClass: this.HypermediaClasses.activities.userChecklistActivity,
 							activityRel: this.HypermediaRels.Checklists.checklistItem,
 							activityClass: 'checklist-item',
@@ -94,7 +94,7 @@
 							activityRel: this.HypermediaRels.Surveys.survey,
 							activityClass: 'survey',
 							noCompletion: false,
-							instructionsRel: 'https://surveys.api.brightspace.com/rels/description',
+							instructionsRel: this.HypermediaRels.Surveys.description,
 							activityDetailsFeatureFlag: 'NOT_IMPLEMENTED'
 						}
 					};

--- a/behaviors/types-behavior.html
+++ b/behaviors/types-behavior.html
@@ -12,19 +12,6 @@
 	*/
 	var typesBehaviorImpl = {
 		properties: {
-			_activityTypes: {
-				type: Array,
-				value: function() {
-					return [
-						this.HypermediaClasses.activities.userAssignmentActivity,
-						this.HypermediaClasses.activities.userQuizActivity,
-						this.HypermediaClasses.activities.userDiscussionActivity,
-						this.HypermediaClasses.activities.userContentActivity,
-						this.HypermediaClasses.activities.userChecklistActivity,
-						this.HypermediaClasses.activities.userSurveyActivity
-					];
-				}
-			},
 			_types: {
 				type: Object,
 				value: function() {

--- a/behaviors/types-behavior.html
+++ b/behaviors/types-behavior.html
@@ -27,25 +27,17 @@
 							noCompletion: false,
 							activityDetailsFeatureFlag: 'assignmentDetailsEnabled'
 						},
-						discussion: {
-							icon: 'discussions',
-							assessmentType: 'discussion',
-							canOpen: true,
-							instructionsRel: this.HypermediaRels.Discussions.description,
-							userActivityUsageClass: this.HypermediaClasses.activities.userDiscussionActivity,
-							activityRel: this.HypermediaRels.Discussions.topic,
-							activityClass: this.HypermediaClasses.discussions.topic,
-							noCompletion: true,
-							activityDetailsFeatureFlag: 'discussionDetailsEnabled'
-						},
-						quiz: {
-							icon: 'quizzing',
-							assessmentType: 'quiz',
+						checklistItem: {
+							icon: function(assessmentItem) {
+								// checklist doesn't have a tier 3 icon
+								return assessmentItem.tier2IconKey || 'd2l-tier2:checklist';
+							},
+							assessmentType: 'checklistItem',
 							canOpen: false,
-							instructionsRel: this.HypermediaRels.Quizzes.description,
-							userActivityUsageClass: this.HypermediaClasses.activities.userQuizActivity,
-							activityRel: this.HypermediaRels.quiz,
-							activityClass: this.HypermediaClasses.quizzes.quiz,
+							instructionsRel: 'https://checklists.api.brightspace.com/rels/description',
+							userActivityUsageClass: this.HypermediaClasses.activities.userChecklistActivity,
+							activityRel: this.HypermediaRels.Checklists.checklistItem,
+							activityClass: 'checklist-item',
 							noCompletion: false,
 							activityDetailsFeatureFlag: 'NOT_IMPLEMENTED'
 						},
@@ -68,13 +60,49 @@
 							activityClass: this.HypermediaClasses.content.sequencedActivity,
 							noCompletion: false,
 							activityDetailsFeatureFlag: 'NOT_IMPLEMENTED'
+						},
+						discussion: {
+							icon: 'discussions',
+							assessmentType: 'discussion',
+							canOpen: true,
+							instructionsRel: this.HypermediaRels.Discussions.description,
+							userActivityUsageClass: this.HypermediaClasses.activities.userDiscussionActivity,
+							activityRel: this.HypermediaRels.Discussions.topic,
+							activityClass: this.HypermediaClasses.discussions.topic,
+							noCompletion: true,
+							activityDetailsFeatureFlag: 'discussionDetailsEnabled'
+						},
+						quiz: {
+							icon: 'quizzing',
+							assessmentType: 'quiz',
+							canOpen: false,
+							instructionsRel: this.HypermediaRels.Quizzes.description,
+							userActivityUsageClass: this.HypermediaClasses.activities.userQuizActivity,
+							activityRel: this.HypermediaRels.quiz,
+							activityClass: this.HypermediaClasses.quizzes.quiz,
+							noCompletion: false,
+							activityDetailsFeatureFlag: 'NOT_IMPLEMENTED'
+						},
+						survey: {
+							icon: function(assessmentItem) {
+								// survey doesn't have a tier 3 icon
+								return assessmentItem.tier2IconKey || 'd2l-tier2:surveys';
+							},
+							assessmentType: 'survey',
+							canOpen: false,
+							userActivityUsageClass: this.HypermediaClasses.activities.userSurveyActivity,
+							activityRel: this.HypermediaRels.Surveys.survey,
+							activityClass: 'survey',
+							noCompletion: false,
+							instructionsRel: 'https://surveys.api.brightspace.com/rels/description',
+							activityDetailsFeatureFlag: 'NOT_IMPLEMENTED'
 						}
 					};
 				}
 			}
 		},
 
-		_allTypes: ['assignment', 'discussion', 'quiz', 'content'],
+		_allTypes: ['assignment', 'discussion', 'quiz', 'content', 'survey', 'checklistItem'],
 
 		_getActivityType: function(activity) {
 			for (var i = 0; i < this._allTypes.length; i++) {

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "d2l-colors": "^3.1.2",
     "d2l-date-picker": "BrightspaceUI/date-picker#^1.0.0",
     "d2l-fetch-siren-entity-behavior": "Brightspace/d2l-fetch-siren-entity-behavior#^5.0.2",
-    "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^5.31.0",
+    "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^v5.32.0",
     "d2l-icons": "^4.14.2",
     "d2l-link": "^4.0.0",
     "d2l-status-indicator": "^1.0.1",

--- a/build/langterms/en.html
+++ b/build/langterms/en.html
@@ -19,6 +19,7 @@
 				"activityExempted": "Exempted",
 				"activityOverdue": "Overdue",
 				"assignment": "Assignment",
+				"checklistItem": "Checklist Item",
 				"closeSimpleOverlayText": "Back to Dashboard",
 				"closeSimpleOverlayTextMobile": "Dashboard",
 				"content": "Content",
@@ -33,6 +34,7 @@
 				"noAssessmentsInThisTimeFrame": "{userName} doesn't have any work due for this time frame.",
 				"noUpcomingAssessments": "{userName} doesn't have any work due in the next 2 weeks.",
 				"quiz": "Quiz",
+				"survey": "Survey",
 				"today": "Today",
 				"tomorrow": "Tomorrow",
 				"viewAllAssignments": "View all work"

--- a/components/d2l-assessments-list-item.html
+++ b/components/d2l-assessments-list-item.html
@@ -221,7 +221,7 @@
 				return '';
 			}
 
-			return item.icon === 'function'
+			return typeof item.icon === 'function'
 				? item.icon(assessmentItem)
 				: 'd2l-tier2:' + item.icon;
 		},

--- a/components/d2l-assessments-list-item.html
+++ b/components/d2l-assessments-list-item.html
@@ -221,11 +221,9 @@
 				return '';
 			}
 
-			if (typeof item.icon === 'function') {
-				return item.icon(assessmentItem);
-			} else {
-				return 'd2l-tier2:' + item.icon;
-			}
+			return item.icon === 'function'
+				? item.icon(assessmentItem)
+				: 'd2l-tier2:' + item.icon;
 		},
 
 		_getAssessmentType: function(assessmentItem) {

--- a/test/behaviors/d2l-upcoming-assessments-behavior.js
+++ b/test/behaviors/d2l-upcoming-assessments-behavior.js
@@ -395,7 +395,7 @@ describe('d2l upcoming assessments behavior', function() {
 			userUsage = getUserActivityUsage('unsupported');
 			userUsages = parse({ entities: [userUsage] });
 
-			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
+			return component._getUserActivityUsagesInfos(userUsages.entities, overdueUserUsages.entities, getToken, userUrl)
 				.then(function() {
 					expect(component._getOrganizationRequest).to.have.not.been.called;
 					expect(component._getActivityRequest).to.have.not.been.called;
@@ -406,7 +406,7 @@ describe('d2l upcoming assessments behavior', function() {
 			userUsage = getUserActivityUsage('content', false, false, true);
 			userUsages = parse({ entities: [userUsage] });
 
-			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
+			return component._getUserActivityUsagesInfos(userUsages.entities, overdueUserUsages.entities, getToken, userUrl)
 				.then(function() {
 					expect(component._getOrganizationRequest).to.have.not.been.called;
 					expect(component._getActivityRequest).to.have.not.been.called;
@@ -417,7 +417,7 @@ describe('d2l upcoming assessments behavior', function() {
 			userUsage = getUserActivityUsage('content', false, false, false);
 			userUsages = parse({ entities: [userUsage] });
 
-			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
+			return component._getUserActivityUsagesInfos(userUsages.entities, overdueUserUsages.entities, getToken, userUrl)
 				.then(function() {
 					expect(component._getOrganizationRequest).to.have.been.called;
 					expect(component._getActivityRequest).to.have.been.called;
@@ -425,14 +425,14 @@ describe('d2l upcoming assessments behavior', function() {
 		});
 
 		it('should call _getOrganizationRequest for the organization', function() {
-			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
+			return component._getUserActivityUsagesInfos(userUsages.entities, overdueUserUsages.entities, getToken, userUrl)
 				.then(function() {
 					expect(component._getOrganizationRequest).to.have.been.called;
 				});
 		});
 
 		it('should call _getActivityRequest for the activity', function() {
-			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
+			return component._getUserActivityUsagesInfos(userUsages.entities, overdueUserUsages.entities, getToken, userUrl)
 				.then(function() {
 					expect(component._getActivityRequest).to.have.been.called;
 				});
@@ -441,7 +441,7 @@ describe('d2l upcoming assessments behavior', function() {
 		it('should set the info property to the value returned from _getInstructions', function() {
 			component._getInstructions = sandbox.stub().returns('bonita bonita bonita');
 
-			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
+			return component._getUserActivityUsagesInfos(userUsages.entities, overdueUserUsages.entities, getToken, userUrl)
 				.then(function(response) {
 					expect(component._getInstructions).to.be.called;
 					expect(response[0].info).to.equal('bonita bonita bonita');
@@ -451,7 +451,7 @@ describe('d2l upcoming assessments behavior', function() {
 		it('should fail when all the activity requests fail', function() {
 			component._getActivityRequest = sandbox.stub().returns(Promise.resolve(null));
 
-			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
+			return component._getUserActivityUsagesInfos(userUsages.entities, overdueUserUsages.entities, getToken, userUrl)
 				.then(function() {
 					return Promise.reject('Expect failure');
 				})
@@ -466,7 +466,7 @@ describe('d2l upcoming assessments behavior', function() {
 
 			userUsages = parse({ entities: [userUsage, userUsage] });
 
-			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
+			return component._getUserActivityUsagesInfos(userUsages.entities, overdueUserUsages.entities, getToken, userUrl)
 				.then(function(response) {
 					expect(component._getInstructions).to.be.called;
 					expect(response[0].info).to.equal('bonita bonita bonita');
@@ -499,7 +499,7 @@ describe('d2l upcoming assessments behavior', function() {
 				text: 'complete'
 			});
 
-			return component._getUserActivityUsagesInfos(userUsages, overdueUserUsages, getToken, userUrl)
+			return component._getUserActivityUsagesInfos(userUsages.entities, overdueUserUsages.entities, getToken, userUrl)
 				.then(function(response) {
 					expect(response[0].name).to.equal(activityName);
 					expect(response[0].courseName).to.equal(organizationName);

--- a/test/components/d2l-assessments-list-item.js
+++ b/test/components/d2l-assessments-list-item.js
@@ -115,6 +115,30 @@ describe('<d2l-assessments-list-item>', function() {
 			});
 		});
 
+		it('renders the correct data for a survey', function(done) {
+			var surveyItem = setActivityItem('survey');
+
+			Polymer.RenderStatus.afterNextRender(element, () => {
+				expect(element.$$('.assessment-title').textContent).to.equal(surveyItem.name);
+				expect(element.$$('.course-name').textContent).to.equal(surveyItem.courseName);
+				expect(element.$$('.assessment-type').textContent).to.equal(surveyItem.itemType);
+				expect(element.$$('.activity-icon').icon).to.equal('d2l-tier2:surveys');
+				done();
+			});
+		});
+
+		it('renders the correct data for a checklist item', function(done) {
+			var checklistItem = setActivityItem('checklistItem');
+
+			Polymer.RenderStatus.afterNextRender(element, () => {
+				expect(element.$$('.assessment-title').textContent).to.equal(checklistItem.name);
+				expect(element.$$('.course-name').textContent).to.equal(checklistItem.courseName);
+				expect(element.$$('.assessment-type').textContent).to.equal('Checklist Item');
+				expect(element.$$('.activity-icon').icon).to.equal('d2l-tier2:checklist');
+				done();
+			});
+		});
+
 		it('has a completion checkmark when completed', function(done) {
 			setActivityItem('assignment', true);
 			Polymer.RenderStatus.afterNextRender(element, () => {


### PR DESCRIPTION
Some gross things in here. Once BfP is converted to Polymer 3, most of this logic should be centralized into a client SDK that eg. simplifies the activities domain. Possibly also some general logic simplification could be done. (Of course, all my awful code just has to be in a public repo..)