### PR TITLE
touchend makes it so you accidentally click the links while scrolling

### DIFF
--- a/components/d2l-assessments-list-item.js
+++ b/components/d2l-assessments-list-item.js
@@ -270,14 +270,12 @@ Polymer({
 			activityContainer.setAttribute('role', 'link');
 			activityContainer.setAttribute('tabIndex', 0);
 			activityContainer.addEventListener('tap', onTap);
-			activityContainer.addEventListener('touchend', onTap);
 			activityContainer.addEventListener('keydown', onKeydown);
 		} else {
 			activityContainer.classList.remove('has-activity-details');
 			activityContainer.removeAttribute('role', 'link');
 			activityContainer.removeAttribute('tabIndex', 0);
 			activityContainer.removeEventListener('tap', onTap);
-			activityContainer.removeEventListener('touchend', onTap);
 			activityContainer.removeEventListener('keydown', onKeydown);
 		}
 	}


### PR DESCRIPTION
Don't quite know the history of why this is here, but removing it makes it so you don't trigger the link when trying to scroll