### PR TITLE
Abort stale request chains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
 - 10.15.3
-dist: trusty
-sudo: required
 addons:
   chrome: stable
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
 script:
 - set -e
 - polymer test --skip-plugin sauce
-- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then polymer test --skip-plugin local; fi'
+# - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then polymer test --skip-plugin local; fi'
 - if [ "$TRAVIS_BRANCH" == "master" ]; then frauci-update-version; fi
 env:
   global:

--- a/behaviors/d2l-upcoming-assessments-behavior.js
+++ b/behaviors/d2l-upcoming-assessments-behavior.js
@@ -255,13 +255,15 @@ var upcomingAssessmentsBehaviorImpl = {
 
 		this.__getInfoRequest = this.__getInfoRequest
 			.then(() => {
-				this.__getInfoAbortController = new AbortController();
+				if (window.AbortController) {
+					this.__getInfoAbortController = new AbortController();
+				}
 
 				return this._fetchEntityWithToken({
 					link: userUrl,
 					getToken: getToken,
 					requestInit: {
-						signal: this.__getInfoAbortController.signal,
+						signal: (this.__getInfoAbortController || {}).signal,
 					},
 				});
 			})
@@ -278,7 +280,7 @@ var upcomingAssessmentsBehaviorImpl = {
 					userLink: userUrl,
 					getToken: getToken,
 					requestInit: {
-						signal: self.__getInfoAbortController.signal,
+						signal: (self.__getInfoAbortController || {}).signal,
 					}
 				});
 			})
@@ -293,14 +295,15 @@ var upcomingAssessmentsBehaviorImpl = {
 					getToken: getToken,
 				});
 			})
-			.catch(function(e) {
+			.then(function() {
+				self.__getInfoAbortController = null;
+			}, function(e) {
+				self.__getInfoAbortController = null;
+
 				if (!(e instanceof Error) || e.name !== 'AbortError') {
 					self._showError = true;
 					self._firstName = null;
 				}
-			})
-			.finally(() => {
-				self.__getInfoAbortController = null;
 			});
 
 		return this.__getInfoRequest;

--- a/behaviors/d2l-upcoming-assessments-behavior.js
+++ b/behaviors/d2l-upcoming-assessments-behavior.js
@@ -37,9 +37,16 @@ var upcomingAssessmentsBehaviorImpl = {
 		_periodEnd: String
 	},
 
-	_getOrganizationRequest: function(userActivityUsage, getToken, userUrl) {
+	_getOrganizationRequest: function(userActivityUsage, getToken, userUrl, abortController) {
 		var organizationLink = (userActivityUsage.getLinkByRel(Rels.organization) || {}).href;
-		return this._fetchEntityWithToken(organizationLink, getToken, userUrl);
+		return this._fetchEntityWithToken({
+			link: organizationLink,
+			userLink: userUrl,
+			getToken: getToken,
+			requestInit: {
+				signal: abortController && abortController.signal,
+			},
+		});
 	},
 
 	_findActivityHref: function(userActivityUsage) {
@@ -185,11 +192,18 @@ var upcomingAssessmentsBehaviorImpl = {
 		}
 	},
 
-	_getOverdueActivities: function(activitiesEntity, getToken, userUrl) {
+	_getOverdueActivities: function(activitiesEntity, getToken, userUrl, abortController) {
 		var overdueActivitiesLink = (activitiesEntity.getLinkByRel(Rels.Activities.overdue) || {}).href;
 
 		if (overdueActivitiesLink) {
-			return this._fetchEntityWithToken(overdueActivitiesLink, getToken, userUrl);
+			return this._fetchEntityWithToken({
+				link: overdueActivitiesLink,
+				userLink: userUrl,
+				getToken: getToken,
+				requestInit: {
+					signal: abortController && abortController.signal,
+				}
+			});
 		}
 
 		// API doesn't include the overdue link if user doesn't have any overdue activities
@@ -228,8 +242,29 @@ var upcomingAssessmentsBehaviorImpl = {
 	_getInfo: function() {
 		this._showError = false;
 		var self = this;
+		var userUrl = this.userUrl;
+		var getToken = this.getToken;
 
-		return this._fetchEntityWithToken(this.userUrl, this.getToken)
+		if (!this.__getInfoRequest) {
+			this.__getInfoRequest = Promise.resolve();
+		}
+
+		if (this.__getInfoAbortController) {
+			this.__getInfoAbortController.abort();
+		}
+
+		this.__getInfoRequest = this.__getInfoRequest
+			.then(() => {
+				this.__getInfoAbortController = new AbortController();
+
+				return this._fetchEntityWithToken({
+					link: userUrl,
+					getToken: getToken,
+					requestInit: {
+						signal: this.__getInfoAbortController.signal,
+					},
+				});
+			})
 			.then(function(userEntity) {
 				self._firstName = (userEntity.getSubEntityByRel(Rels.firstName) || { properties: {} }).properties.name;
 				var myActivitiesLink = (
@@ -238,24 +273,57 @@ var upcomingAssessmentsBehaviorImpl = {
 					|| {}
 				).href;
 
-				return self._fetchEntityWithToken(myActivitiesLink, self.getToken, self.userUrl);
+				return self._fetchEntityWithToken({
+					link: myActivitiesLink,
+					userLink: userUrl,
+					getToken: getToken,
+					requestInit: {
+						signal: self.__getInfoAbortController.signal,
+					}
+				});
 			})
 			.then(function(activitiesEntity) {
 				self.__activitiesEntity = activitiesEntity;
 
-				return self._loadActivitiesForPeriod(activitiesEntity, new Date());
+				return self._loadActivitiesForPeriod({
+					activitiesEntity: activitiesEntity,
+					dateObj: new Date(),
+					abortController: self.__getInfoAbortController,
+					userUrl: userUrl,
+					getToken: getToken,
+				});
 			})
-			.catch(function() {
-				self._showError = true;
-				self._firstName = null;
+			.catch(function(e) {
+				if (!(e instanceof Error) || e.name !== 'AbortError') {
+					self._showError = true;
+					self._firstName = null;
+				}
+			})
+			.finally(() => {
+				self.__getInfoAbortController = null;
 			});
+
+		return this.__getInfoRequest;
 	},
 
-	_loadActivitiesForPeriod: function(activitiesEntity, dateObj) {
+	_loadActivitiesForPeriod: function({
+		activitiesEntity,
+		dateObj,
+		abortController,
+		getToken,
+		userUrl,
+	}) {
 		var periodUrl = this._getCustomRangeAction(activitiesEntity, dateObj);
 		var self = this;
-		var userActivitiesRequest = this._fetchEntityWithToken(periodUrl, this.getToken, this.userUrl);
-		var overdueActivitiesRequest = this._getOverdueActivities(activitiesEntity, this.getToken, this.userUrl);
+		var userActivitiesRequest = this._fetchEntityWithToken({
+			link: periodUrl,
+			userLink: userUrl,
+			getToken: getToken,
+			requestInit: {
+				signal: abortController && abortController.signal,
+			},
+		});
+		var overdueActivitiesRequest = this._getOverdueActivities(activitiesEntity, getToken, userUrl, abortController);
 
 		return Promise.all([userActivitiesRequest, overdueActivitiesRequest])
 			.then(function(activitiesResponses) {
@@ -267,8 +335,8 @@ var upcomingAssessmentsBehaviorImpl = {
 				self._periodStart = userActivityUsages.properties.start;
 				self._periodEnd = userActivityUsages.properties.end;
 
-				var flattenActivityUsages = self._flattenActivities(userActivityUsages);
-				var flattenOverdueActivityUsages = self._flattenActivities(overdueUserActivityUsages);
+				var flattenActivityUsages = self._flattenActivities(userActivityUsages, getToken, userUrl, abortController);
+				var flattenOverdueActivityUsages = self._flattenActivities(overdueUserActivityUsages, getToken, userUrl, abortController);
 				return Promise.all([
 					flattenActivityUsages,
 					flattenOverdueActivityUsages
@@ -276,13 +344,14 @@ var upcomingAssessmentsBehaviorImpl = {
 					return self._getUserActivityUsagesInfos(
 						responses[0],
 						responses[1],
-						self.getToken,
-						self.userUrl
+						getToken,
+						userUrl,
+						abortController,
 					);
 				});
 			})
 			.then(function(userActivityUsagesInfos) {
-				var activities = self._updateActivitiesInfo(userActivityUsagesInfos, self.getToken, self.userUrl);
+				var activities = self._updateActivitiesInfo(userActivityUsagesInfos, getToken, userUrl);
 
 				self.set('_allActivities', activities);
 				return activities;
@@ -336,7 +405,7 @@ var upcomingAssessmentsBehaviorImpl = {
 	* Linked subentities are hydrated, and the date restrictions of the
 	* parent content activity are projected onto the child activity when missing.
 	*/
-	_flattenActivities: function(activities) {
+	_flattenActivities: function(activities, getToken, userUrl, abortController) {
 		var activityEntities;
 		var self = this;
 		if (Array.isArray(activities)) {
@@ -347,7 +416,7 @@ var upcomingAssessmentsBehaviorImpl = {
 		var supportedActivities = activityEntities.filter(this._isSupportedType.bind(this));
 		var activitiesContext = this._createNormalizedEntityMap(supportedActivities);
 		var flattenedActivities = Array.from(activitiesContext.activitiesMap.values());
-		return self._hydrateActivityEntities(flattenedActivities)
+		return self._hydrateActivityEntities(flattenedActivities, getToken, userUrl, abortController)
 			.then(function(hydratedActivities) {
 				var activitiesMap = activitiesContext.activitiesMap;
 				var parentActivitiesMap = activitiesContext.parentActivitiesMap;
@@ -404,7 +473,7 @@ var upcomingAssessmentsBehaviorImpl = {
 					// helper functions, so, re-parse if so.
 					if (childActivity.href) {
 						var childActivityHref = childActivity.href; // Save because parsing it in isolation dumps this..
-						childActivity =  SirenParse(childActivity);
+						childActivity = SirenParse(childActivity);
 						childActivity.href = childActivityHref;
 					}
 					var childSelfLink = childActivity.href || (childActivity.getLinkByRel('self') || {}).href;
@@ -434,7 +503,7 @@ var upcomingAssessmentsBehaviorImpl = {
 	/*
 	* On success, all activities, with linked subentities hydrated
 	*/
-	_hydrateActivityEntities: function(activityEntities) {
+	_hydrateActivityEntities: function(activityEntities, getToken, userUrl, abortController) {
 		var self = this;
 		// Already-complete entities
 		var hydratedActivities = activityEntities
@@ -446,7 +515,14 @@ var upcomingAssessmentsBehaviorImpl = {
 				return entity.href;
 			})
 			.map(function(entity) {
-				return self._fetchEntityWithToken(entity.href, self.getToken, self.userUrl)
+				return self._fetchEntityWithToken({
+					link: entity.href,
+					userLink: userUrl,
+					getToken: getToken,
+					requestInit: {
+						signal: abortController && abortController.signal,
+					}
+				})
 					.then(SirenParse);
 			});
 		return Promise.all(activityPromises)

--- a/components/d2l-all-assessments.js
+++ b/components/d2l-all-assessments.js
@@ -117,22 +117,16 @@ Polymer({
 				this.__dateChangeActivityLoadRequest = Promise.resolve();
 			}
 
-			const ctx = {
-				activitiesEntity: this.__activitiesEntity,
-				getToken: this.getToken,
-				userUrl: this.userUrl,
-			};
-
 			this.__dateChangeActivityLoadRequest = this.__dateChangeActivityLoadRequest
 				.then(() => {
 					this.__dateChangeAbortController = new AbortController();
 
 					return this._loadActivitiesForPeriod({
-						activitiesEntity: ctx.activitiesEntity,
+						activitiesEntity: this.__activitiesEntity,
 						dateObj: e.detail.date,
 						abortSignal: (this.__dateChangeAbortController || {}).signal,
-						getToken: ctx.getToken,
-						userUrl: ctx.userUrl,
+						getToken: this.getToken,
+						userUrl: this.userUrl,
 					});
 				})
 				.then(this._formatPeriodText.bind(this))

--- a/components/d2l-all-assessments.js
+++ b/components/d2l-all-assessments.js
@@ -136,14 +136,15 @@ Polymer({
 					});
 				})
 				.then(this._formatPeriodText.bind(this))
-				.catch((e) => {
+				.then(() => {
+					this.__dateChangeAbortController = null;
+				}, (e) => {
+					this.__dateChangeAbortController = null;
+
 					if (!(e instanceof Error) || e.name !== 'AbortError') {
 						this._showError = true;
 						this._firstName = null;
 					}
-				})
-				.finally(() => {
-					this.__dateChangeAbortController = null;
 				});
 
 			return this.__dateChangeActivityLoadRequest;

--- a/components/d2l-all-assessments.js
+++ b/components/d2l-all-assessments.js
@@ -51,7 +51,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-all-assessments">
 		</template>
 		<div hidden$="[[_hasActivities(_allActivities)]]" class="no-assessments-in-time-frame">[[_noAssessmentsInThisTimeFrame]]</div>
 	</template>
-	
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);
@@ -95,6 +94,10 @@ Polymer({
 	},
 
 	_getAllAssessmentsInfo: function() {
+		if (this.__dateChangeAbortController) {
+			this.__dateChangeAbortController.abort();
+		}
+
 		this._resetData();
 		this._getInfo()
 			.then(this._formatPeriodText.bind(this));
@@ -106,12 +109,44 @@ Polymer({
 
 	_onDateValueChanged: function(e) {
 		if (e.detail.date) {
-			return this._loadActivitiesForPeriod(this.__activitiesEntity, e.detail.date)
+			if (this.__dateChangeAbortController) {
+				this.__dateChangeAbortController.abort();
+			}
+
+			if (!this.__dateChangeActivityLoadRequest) {
+				this.__dateChangeActivityLoadRequest = Promise.resolve();
+			}
+
+			const ctx = {
+				activitiesEntity: this.__activitiesEntity,
+				getToken: this.getToken,
+				userUrl: this.userUrl,
+			};
+
+			this.__dateChangeActivityLoadRequest = this.__dateChangeActivityLoadRequest
+				.then(() => {
+					this.__dateChangeAbortController = new AbortController();
+
+					return this._loadActivitiesForPeriod({
+						activitiesEntity: ctx.activitiesEntity,
+						dateObj: e.detail.date,
+						abortController: this.__dateChangeAbortController,
+						getToken: ctx.getToken,
+						userUrl: ctx.userUrl,
+					});
+				})
 				.then(this._formatPeriodText.bind(this))
-				.catch(function() {
-					self._showError = true;
-					self._firstName = null;
+				.catch((e) => {
+					if (!(e instanceof Error) || e.name !== 'AbortError') {
+						this._showError = true;
+						this._firstName = null;
+					}
+				})
+				.finally(() => {
+					this.__dateChangeAbortController = null;
 				});
+
+			return this.__dateChangeActivityLoadRequest;
 		}
 	},
 

--- a/components/d2l-all-assessments.js
+++ b/components/d2l-all-assessments.js
@@ -130,7 +130,7 @@ Polymer({
 					return this._loadActivitiesForPeriod({
 						activitiesEntity: ctx.activitiesEntity,
 						dateObj: e.detail.date,
-						abortController: this.__dateChangeAbortController,
+						abortSignal: (this.__dateChangeAbortController || {}).signal,
 						getToken: ctx.getToken,
 						userUrl: ctx.userUrl,
 					});

--- a/test/behaviors/d2l-upcoming-assessments-behavior.js
+++ b/test/behaviors/d2l-upcoming-assessments-behavior.js
@@ -622,7 +622,7 @@ describe('d2l upcoming assessments behavior', function() {
 			component.userUrl = 'http://example.com';
 
 			return component._getInfo().then(function() {
-				expect(component._fetchEntityWithToken).to.have.been.calledWith('http://example.com');
+				expect(component._fetchEntityWithToken.getCall(0).args[0].link).to.equal('http://example.com');
 			});
 		});
 
@@ -660,13 +660,13 @@ describe('d2l upcoming assessments behavior', function() {
 				component._fetchEntityWithToken.onFirstCall().returns(Promise.resolve(parsedUserEntity));
 
 				return component._getInfo().then(function() {
-					expect(component._fetchEntityWithToken.getCall(1).args[0]).to.equal(ctx.expectedLink);
+					expect(component._fetchEntityWithToken.getCall(1).args[0].link).to.equal(ctx.expectedLink);
 				});
 			});
 		});
 
 		it('should set the error state if things go wrong', function() {
-			component._loadActivitiesForPeriod = sinon.stub().returns(Promise.reject());
+			component._loadActivitiesForPeriod = sinon.stub().returns(Promise.reject(Error()));
 
 			return component._getInfo().then(function() {
 				expect(component._showError).to.be.true;
@@ -699,9 +699,14 @@ describe('d2l upcoming assessments behavior', function() {
 
 			const parsedActivitiesEntity = SirenParse(activitiesEntity);
 
-			return component._loadActivitiesForPeriod(parsedActivitiesEntity, new Date('2017-07-21T16:20:07.567Z'))
+			return component._loadActivitiesForPeriod({
+				activitiesEntity: parsedActivitiesEntity,
+				dateObj: new Date('2017-07-21T16:20:07.567Z'),
+				getToken: getToken,
+				userUrl: userUrl,
+			})
 				.then(function() {
-					expect(component._fetchEntityWithToken).to.have.been.calledWith(`http://www.foo.com?start=${startDate}&end=${endDate}`);
+					expect(component._fetchEntityWithToken.getCall(0).args[0].link).to.equal(`http://www.foo.com?start=${startDate}&end=${endDate}`);
 					expect(component._allActivities).to.equal(activities);
 				});
 		});
@@ -709,7 +714,12 @@ describe('d2l upcoming assessments behavior', function() {
 		it('should not update the assessments with the activities in the period', function() {
 			const parsedActivitiesEntity = SirenParse(activitiesEntity);
 
-			return component._loadActivitiesForPeriod(parsedActivitiesEntity, new Date('2017-07-21T16:20:07.567Z'))
+			return component._loadActivitiesForPeriod({
+				activitiesEntity: parsedActivitiesEntity,
+				dateObj: new Date('2017-07-21T16:20:07.567Z'),
+				getToken: getToken,
+				userUrl: userUrl,
+			})
 				.then(function() {
 					expect(component._assessments).to.not.equal(activities);
 				});

--- a/test/components/d2l-all-assessments.js
+++ b/test/components/d2l-all-assessments.js
@@ -72,7 +72,7 @@ describe('<d2l-all-assessments>', function() {
 
 				return element._onDateValueChanged(dateObj)
 					.then(function() {
-						expect(element._loadActivitiesForPeriod).to.have.been.calledWith(activitiesEntity);
+						expect(element._loadActivitiesForPeriod.getCall(0).args[0].activitiesEntity).to.equal(activitiesEntity);
 					});
 			});
 		});


### PR DESCRIPTION
DE38539

This updates requests to use [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)/[AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) in order to terminate request chains on user context changes.