### PR TITLE
US128081 Don't filter out broken content items

### DIFF
--- a/behaviors/d2l-upcoming-assessments-behavior.js
+++ b/behaviors/d2l-upcoming-assessments-behavior.js
@@ -394,8 +394,7 @@ var upcomingAssessmentsBehaviorImpl = {
 			activityEntities = activities.entities || [];
 		}
 		const supportedActivities = activityEntities
-			.filter(this._isSupportedType.bind(this))
-			.filter(x => !x.hasClass('broken'));
+			.filter(this._isSupportedType.bind(this));
 
 		const activitiesContext = this._createNormalizedEntityMap(supportedActivities);
 		const flattenedActivities = Array.from(activitiesContext.activitiesMap.values());


### PR DESCRIPTION
The LMS is now going to filter these out server-side, so there's no need for this logic to exist anymore. Not really harmful to leave, but it's now a no-op, so might as well clean it up.

Note that the LMS PR hasn't merged yet, and I'm not sure how this gets released - I'll at the very least wait until the LMS PR is merged before merging this, but does parent-portal-ui just automatically pull in new versions of this?