### PR TITLE
Update dependencies

### DIFF
--- a/behaviors/d2l-upcoming-assessments-behavior.js
+++ b/behaviors/d2l-upcoming-assessments-behavior.js
@@ -354,7 +354,7 @@ var upcomingAssessmentsBehaviorImpl = {
 		const query = {};
 		if (action.fields) {
 			action.fields.forEach((field) => {
-				if (parameters.hasOwnProperty(field.name)) {
+				if (parameters.hasOwnProperty(field.name)) { // eslint-disable-line no-prototype-builtins
 					query[field.name] = parameters[field.name];
 				} else if (field.value !== undefined) {
 					query[field.name] = field.value;

--- a/behaviors/status-badge-behavior.js
+++ b/behaviors/status-badge-behavior.js
@@ -11,12 +11,12 @@ window.D2L.UpcomingAssessments = window.D2L.UpcomingAssessments || {};
 */
 var statusBadgeBehaviorImpl = {
 	properties: {},
-	_completeState: {text: 'activityComplete', state: 'success'},
-	_endedState: {text: 'activityEnded', state: 'null'},
-	_exemptedState: {text: 'activityExempted', state: 'success'},
-	_overdueState: {text: 'activityOverdue', state: 'alert'},
-	_dueTodayState: {text: 'activityDueToday', state: 'default'},
-	_endsTodayState: {text: 'activityEndsToday', state: 'default'},
+	_completeState: { text: 'activityComplete', state: 'success' },
+	_endedState: { text: 'activityEnded', state: 'null' },
+	_exemptedState: { text: 'activityExempted', state: 'success' },
+	_overdueState: { text: 'activityOverdue', state: 'alert' },
+	_dueTodayState: { text: 'activityDueToday', state: 'default' },
+	_endsTodayState: { text: 'activityEndsToday', state: 'default' },
 
 	_createStatusConfig: function(isCompleted, isEnded, isExempt, isOverdue, isDueToday, endsToday) {
 		var statusConfig = null;

--- a/components/d2l-date-dropdown.js
+++ b/components/d2l-date-dropdown.js
@@ -200,7 +200,7 @@ Polymer({
 		if (!useShadow) {
 			this.dispatchEvent(new CustomEvent(
 				'focus',
-				{bubbles: true, composed: false}
+				{ bubbles: true, composed: false }
 			));
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "gulp build",
     "test": "npm run test:lint:js && npm run test:lint:wc && npm run test:wct",
     "test:local": "npm run test:lint:js && npm run test:lint:wc && npm run test:wct:local",
-    "test:lint:js": "eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.js demo/**/*.html",
+    "test:lint:js": "eslint . --ext .js,.html",
     "test:lint:wc": "polymer lint",
     "test:wct": "polymer test -p",
     "test:wct:local": "cross-env LAUNCHPAD_BROWSERS=chrome polymer test -p --skip-plugin sauce"
@@ -29,26 +29,25 @@
     "url": "https://github.com/Brightspace/upcoming-assessments-ui/issues"
   },
   "devDependencies": {
-    "@polymer/iron-component-page": "^4.0.0",
-    "@polymer/iron-demo-helpers": "^3.0.0",
-    "@webcomponents/webcomponentsjs": "^2.2.6",
-    "babel-eslint": "^10.0.1",
-    "cross-env": "^5.0.1",
-    "del": "^3.0.0",
-    "eslint": "^4.13.1",
-    "eslint-config-brightspace": "^0.5.3",
-    "eslint-config-google": "^0.9.1",
-    "eslint-plugin-html": "~4.0.1",
-    "frau-ci": "^1.33.2",
-    "gulp": "^4.0.0",
-    "gulp-cli": "^2.0.1",
-    "gulp-ejs": "^3.1.3",
-    "gulp-rename": "^1.2.3",
-    "merge-stream": "^1.0.1",
-    "polymer-cli": "^1.9.5",
-    "require-dir": "^1.0.0",
-    "wct-browser-legacy": "^1.0.1",
-    "web-component-tester": "^6.5.0"
+    "@babel/eslint-parser": "^7.14.7",
+    "@polymer/iron-demo-helpers": "^3.1.0",
+    "@webcomponents/webcomponentsjs": "^2.5.0",
+    "cross-env": "^7.0.3",
+    "del": "^6.0.0",
+    "eslint": "^7.29.0",
+    "eslint-config-brightspace": "^0.14.1",
+    "eslint-plugin-html": "^6.1.2",
+    "eslint-plugin-sort-class-members": "^1.11.0",
+    "frau-ci": "^1.42.2",
+    "gulp": "^4.0.2",
+    "gulp-cli": "^2.3.0",
+    "gulp-ejs": "^5.1.0",
+    "gulp-rename": "^2.0.0",
+    "merge-stream": "^2.0.0",
+    "polymer-cli": "^1.9.11",
+    "require-dir": "^1.2.0",
+    "wct-browser-legacy": "^1.0.2",
+    "web-component-tester": "^6.9.2"
   },
   "resolutions": {
     "inherits": "2.0.3",
@@ -66,9 +65,8 @@
     "d2l-link": "BrightspaceUI/link#semver:^5",
     "d2l-status-indicator": "BrightspaceUI/status-indicator#semver:^3",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
-    "whatwg-fetch": "^2.0.0",
-    "@polymer/iron-a11y-keys": "^3.0.0",
-    "@polymer/polymer": "^3.0.0",
-    "siren-parser": "^8.0.0"
+    "@polymer/iron-a11y-keys": "^3.0.1",
+    "@polymer/polymer": "^3.4.1",
+    "siren-parser": "^8.4.0"
   }
 }

--- a/test/behaviors/d2l-upcoming-assessments-behavior.js
+++ b/test/behaviors/d2l-upcoming-assessments-behavior.js
@@ -1,5 +1,3 @@
-/* global describe, it, expect, fixture, beforeEach, afterEach, sinon */
-
 import SirenParse from 'siren-parser';
 import './d2l-upcoming-assessments-behavior-consumer.js';
 
@@ -736,7 +734,7 @@ describe('d2l upcoming assessments behavior', function() {
 		permutations = addPermutations(permutations, 'endsToday');
 
 		permutations.forEach(function(permutation) {
-			var {isCompleted, isDueToday, isOverdue, isEnded, isExempt, endsToday} = permutation;
+			var { isCompleted, isDueToday, isOverdue, isEnded, isExempt, endsToday } = permutation;
 			var testName = `when activity is ${isCompleted ? '' : 'not'} completed`
 					+ ` and is ${isDueToday ? '' : 'not'} due today`
 					+ ` and is ${isOverdue ? '' : 'not'} overdue`

--- a/test/behaviors/date-behavior.js
+++ b/test/behaviors/date-behavior.js
@@ -1,5 +1,3 @@
-/* global describe, it, expect, fixture, beforeEach, expect */
-
 'use strict';
 
 describe('date behavior', function() {

--- a/test/components/d2l-all-assessments-list-item.js
+++ b/test/components/d2l-all-assessments-list-item.js
@@ -1,5 +1,3 @@
-/* global describe, it, fixture, expect, beforeEach, sinon */
-
 describe('<d2l-all-assessments-list-item>', function() {
 	var element;
 

--- a/test/components/d2l-all-assessments.js
+++ b/test/components/d2l-all-assessments.js
@@ -1,5 +1,3 @@
-/* global describe, it, fixture, expect, beforeEach, afterEach, sinon */
-
 'use strict';
 
 describe('<d2l-all-assessments>', function() {

--- a/test/components/d2l-assessments-list-item.js
+++ b/test/components/d2l-assessments-list-item.js
@@ -1,5 +1,3 @@
-/* global describe, it, fixture, expect */
-
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
 describe('<d2l-assessments-list-item>', function() {

--- a/test/components/d2l-assessments-list.js
+++ b/test/components/d2l-assessments-list.js
@@ -1,5 +1,3 @@
-/* global describe, it, fixture, expect, beforeEach */
-
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
 

--- a/test/components/d2l-date-dropdown.js
+++ b/test/components/d2l-date-dropdown.js
@@ -1,5 +1,3 @@
-/* global describe, it, fixture, expect, beforeEach */
-
 'use strict';
 
 describe('<d2l-date-dropdown>', function() {

--- a/test/components/d2l-upcoming-assessments.js
+++ b/test/components/d2l-upcoming-assessments.js
@@ -1,5 +1,3 @@
-/* global describe, it, fixture, expect, beforeEach, afterEach, sinon */
-
 'use strict';
 
 describe('<d2l-upcoming-assessments>', function() {

--- a/test/index.html
+++ b/test/index.html
@@ -8,7 +8,6 @@
 	</head>
 	<body>
 		<script>
-			/* global WCT */
 			'use strict';
 			// Load and run all tests (.html, .js):
 			WCT.loadSuites([


### PR DESCRIPTION
Was seeing some ESLint failures in #179, and realized that we're pretty out of date. Sure enough, updating that cleared the errors, so figured might as well update everything else while I'm here. This is mostly devDependency changes, with the exceptions being a minor bump to `siren-parser`, and removing `whatwg-fetch`, which was unused.