### PR TITLE
US128094 Fix date handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
 script:
 - set -e
 - polymer test --skip-plugin sauce
+- npm run test:wtr
 # - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then polymer test --skip-plugin local; fi'
 - if [ "$TRAVIS_BRANCH" == "master" ]; then frauci-update-version; fi
 env:

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.14.7",
+    "@open-wc/testing": "^2.5.33",
     "@polymer/iron-demo-helpers": "^3.1.0",
     "@web/dev-server": "^0.1.17",
     "@web/test-runner": "^0.13.13",


### PR DESCRIPTION
Followup/fix for #179.

There were two issues here causing weird behaviour with the date selector. First, by setting the `value` on the selector we create some strange cyclical behaviour, exacerbated by the problem outlined below. To avoid this, but to also avoid a blank date selector initially, we just set the date to "today" via a throwaway value. Once a date has been selected by a user, at that point it will just display the selected date.

The second issue was mostly apparently when selecting a date at the beginning of end of a week (i.e. Sunday or Saturday), as the offsets along with the cyclical behaviour mentioned above meant the calendar would go back a week every time you opened it. This was solved by adding the offset to the date value the `d2l-date-input` gives us, then working with that. This has the effect of turning the midnight-UTC the selector gives us into an equivalent datetime that is midnight-UTC but in the local timezone.